### PR TITLE
Fixed a race condition causing flakey test runs

### DIFF
--- a/pkg/f1/run/result.go
+++ b/pkg/f1/run/result.go
@@ -156,6 +156,9 @@ var (
 	timeout = template.Must(template.New("timeout").
 		Funcs(templateFunctions).
 		Parse(`{cyan}[{{durationSeconds .Duration | printf "%5s"}}]  Max Duration Elapsed - waiting for active tests to complete{-}`))
+	maxIterationsReached = template.Must(template.New("maxIterationsReached").
+				Funcs(templateFunctions).
+				Parse(`{cyan}[{{durationSeconds .Duration | printf "%5s"}}]  Max Iterations Reached - waiting for active tests to complete{-}`))
 	interrupt = template.Must(template.New("interrupt").
 			Funcs(templateFunctions).
 			Parse(`{cyan}[{{durationSeconds .Duration | printf "%5s"}}]  Interrupted - waiting for active tests to complete{-}`))
@@ -238,4 +241,10 @@ func (r *RunResult) RecordTestFinished() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.TestDuration = time.Since(r.startTime)
+}
+
+func (r *RunResult) MaxIterationsReached() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return renderTemplate(maxIterationsReached, r)
 }

--- a/pkg/f1/run/run_cmd_test.go
+++ b/pkg/f1/run/run_cmd_test.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"os"
 	"testing"
 	"time"
 )
@@ -183,11 +182,6 @@ func TestParameterised(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if test.name == "limited iterations running for multiple loops" || test.name == "limited iterations" {
-				os.Setenv("TRACE", "true")
-				defer os.Setenv("TRACE", "false")
-			}
-
 			given, when, then := NewRunTestStage(t)
 
 			given.

--- a/pkg/f1/run/run_cmd_test.go
+++ b/pkg/f1/run/run_cmd_test.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"os"
 	"testing"
 	"time"
 )
@@ -182,6 +183,11 @@ func TestParameterised(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			if test.name == "limited iterations" {
+				os.Setenv("TRACE", "true")
+				defer os.Setenv("TRACE", "false")
+			}
+
 			given, when, then := NewRunTestStage(t)
 
 			given.

--- a/pkg/f1/run/run_cmd_test.go
+++ b/pkg/f1/run/run_cmd_test.go
@@ -183,7 +183,7 @@ func TestParameterised(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if test.name == "limited iterations" {
+			if test.name == "limited iterations running for multiple loops" || test.name == "limited iterations" {
 				os.Setenv("TRACE", "true")
 				defer os.Setenv("TRACE", "false")
 			}

--- a/pkg/f1/run/run_stage_test.go
+++ b/pkg/f1/run/run_stage_test.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"fmt"
+	"math"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -104,7 +105,12 @@ func (s *RunTestStage) i_start_a_timer() *RunTestStage {
 
 func (s *RunTestStage) the_command_should_have_run_for_approx(expectedDuration time.Duration) *RunTestStage {
 	if expectedDuration > 0 {
-		s.assert.Equal(expectedDuration, s.runResult.TestDuration.Round(expectedDuration/5), "test run time")
+		diff := s.runResult.TestDuration - expectedDuration
+		msg := fmt.Sprintf(
+			"difference between expected (%f) an actual (%f) durations was more than 20%%",
+			expectedDuration.Seconds(),
+			s.runResult.TestDuration.Seconds())
+		s.assert.LessOrEqual(math.Abs(diff.Seconds()), expectedDuration.Seconds()*0.2, msg)
 	}
 	return s
 }

--- a/pkg/f1/run/run_stage_test.go
+++ b/pkg/f1/run/run_stage_test.go
@@ -106,11 +106,18 @@ func (s *RunTestStage) i_start_a_timer() *RunTestStage {
 func (s *RunTestStage) the_command_should_have_run_for_approx(expectedDuration time.Duration) *RunTestStage {
 	if expectedDuration > 0 {
 		diff := s.runResult.TestDuration - expectedDuration
+		// Generally, we want timings to be within 100ms of our expected values, but where the expectation
+		// is greater than 1 second, within 500ms is close enough.
+		marginForError := (100 * time.Millisecond).Seconds()
+		if expectedDuration.Seconds() > 1 {
+			marginForError = (500 * time.Millisecond).Seconds()
+		}
 		msg := fmt.Sprintf(
-			"difference between expected (%f) an actual (%f) durations was more than 20%%",
+			"difference between expected (%fs) an actual (%fs) durations was more than %fs",
 			expectedDuration.Seconds(),
-			s.runResult.TestDuration.Seconds())
-		s.assert.LessOrEqual(math.Abs(diff.Seconds()), expectedDuration.Seconds()*0.2, msg)
+			s.runResult.TestDuration.Seconds(),
+			marginForError)
+		s.assert.LessOrEqual(math.Abs(diff.Seconds()), marginForError, msg)
 	}
 	return s
 }

--- a/pkg/f1/run/test_runner.go
+++ b/pkg/f1/run/test_runner.go
@@ -12,20 +12,20 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/form3tech-oss/f1/pkg/f1/raterunner"
-
-	"github.com/form3tech-oss/f1/pkg/f1/options"
-
-	"github.com/pkg/errors"
-
 	"github.com/form3tech-oss/f1/pkg/f1/logging"
+	"github.com/form3tech-oss/f1/pkg/f1/options"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/form3tech-oss/f1/pkg/f1/trace"
+
+	"github.com/form3tech-oss/f1/pkg/f1/raterunner"
 
 	"github.com/form3tech-oss/f1/pkg/f1/trigger/api"
 
 	"github.com/aholic/ggtimer"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/form3tech-oss/f1/pkg/f1/metrics"
 	"github.com/form3tech-oss/f1/pkg/f1/testing"
@@ -187,12 +187,24 @@ func (r *Run) run() {
 	r.result.RecordStarted()
 	defer r.result.RecordTestFinished()
 
-	doWork := make(chan bool, workers)
+	workTriggered := make(chan bool, workers)
 	stopTrigger := make(chan bool, 1)
-	go r.trigger.Trigger(doWork, stopTrigger, workDone, r.Options)
+	go r.trigger.Trigger(workTriggered, stopTrigger, workDone, r.Options)
+
+	// This blocks waiting for cancellable timer
+	go func() {
+		<-durationElapsed.C
+		trace.ReceivedFromChannel("C")
+		fmt.Println(r.result.MaxDurationElapsed())
+		log.Info("Stopping worker")
+		stopTrigger <- true
+		close(stopWorkers)
+		wg.Wait()
+	}()
 
 	// run more iterations on every tick, until duration has elapsed.
 	for {
+		trace.Event("Run loop ")
 		select {
 		case <-r.interrupt:
 			fmt.Println(r.result.Interrupted())
@@ -200,15 +212,13 @@ func (r *Run) run() {
 			// stop listening to interrupts - second interrupt will terminate immediately
 			signal.Stop(r.interrupt)
 			durationElapsed.Cancel()
-		case <-durationElapsed.C:
-			fmt.Println(r.result.MaxDurationElapsed())
-			log.Info("Stopping worker")
-			stopTrigger <- true
-			close(stopWorkers)
+		case <-workTriggered:
+			trace.ReceivedFromChannel("workTriggered")
+			r.doWork(doWorkChannel, durationElapsed)
+			trace.Event("Called do work")
+		case <-stopWorkers:
 			wg.Wait()
 			return
-		case <-doWork:
-			r.doWork(doWorkChannel, durationElapsed)
 		}
 	}
 }
@@ -223,10 +233,12 @@ func (r *Run) doWork(doWorkChannel chan<- int32, durationElapsed *testing.Cancel
 		return
 	}
 	iteration := atomic.AddInt32(&r.iteration, 1)
-	if r.Options.MaxIterations > 0 && iteration == r.Options.MaxIterations {
-		doWorkChannel <- iteration
+	if r.Options.MaxIterations > 0 && iteration > r.Options.MaxIterations {
+		trace.Event("Max iterations exceeded Calling Cancel on iteration  '%v' .", iteration)
 		durationElapsed.Cancel()
-	} else if r.Options.MaxIterations <= 0 || iteration < r.Options.MaxIterations {
+		trace.Event("Max iterations exceeded Called Cancel on iteration  '%v' .", iteration)
+	} else if r.Options.MaxIterations <= 0 || iteration <= r.Options.MaxIterations {
+		trace.Event("Within Max iterations So calling dowork() on iteration  '%v' .", iteration)
 		doWorkChannel <- iteration
 	}
 }
@@ -282,13 +294,16 @@ func (r *Run) gatherProgressMetrics(duration time.Duration) {
 
 func (r *Run) runWorker(input <-chan int32, stop <-chan struct{}, wg *sync.WaitGroup, worker string, workDone chan<- bool) {
 	defer wg.Done()
+	trace.Event("Started worker (%v)", worker)
 	for {
 		select {
 		case <-stop:
+			trace.Event("Stopping worker (%v)", worker)
 			return
 		case iteration := <-input:
 			// if both stop chan is closed and input ch has more iterations,
 			// select will choose a random case. double check if we need to stop
+			trace.Event("Received work (%v) from Channel 'doWork' iteration (%v)", worker, iteration)
 			select {
 			case <-stop:
 				return
@@ -311,6 +326,9 @@ func (r *Run) runWorker(input <-chan int32, stop <-chan struct{}, wg *sync.WaitG
 			case <-stop:
 				return
 			}
+
+			trace.Event("Completed iteration (%v).", iteration)
+
 		}
 	}
 }

--- a/pkg/f1/run/test_runner.go
+++ b/pkg/f1/run/test_runner.go
@@ -193,9 +193,11 @@ func (r *Run) run() {
 
 	// This blocks waiting for cancellable timer
 	go func() {
-		<-durationElapsed.C
+		elapsed := <-durationElapsed.C
 		trace.ReceivedFromChannel("C")
-		fmt.Println(r.result.MaxDurationElapsed())
+		if elapsed {
+			fmt.Println(r.result.MaxDurationElapsed())
+		}
 		log.Info("Stopping worker")
 		stopTrigger <- true
 		close(stopWorkers)
@@ -235,7 +237,9 @@ func (r *Run) doWork(doWorkChannel chan<- int32, durationElapsed *testing.Cancel
 	iteration := atomic.AddInt32(&r.iteration, 1)
 	if r.Options.MaxIterations > 0 && iteration > r.Options.MaxIterations {
 		trace.Event("Max iterations exceeded Calling Cancel on iteration  '%v' .", iteration)
-		durationElapsed.Cancel()
+		if durationElapsed.Cancel() {
+			fmt.Println(r.result.MaxIterationsReached())
+		}
 		trace.Event("Max iterations exceeded Called Cancel on iteration  '%v' .", iteration)
 	} else if r.Options.MaxIterations <= 0 || iteration <= r.Options.MaxIterations {
 		trace.Event("Within Max iterations So calling dowork() on iteration  '%v' .", iteration)

--- a/pkg/f1/run/test_runner.go
+++ b/pkg/f1/run/test_runner.go
@@ -301,14 +301,7 @@ func (r *Run) runWorker(input <-chan int32, stop <-chan struct{}, wg *sync.WaitG
 			trace.Event("Stopping worker (%v)", worker)
 			return
 		case iteration := <-input:
-			// if both stop chan is closed and input ch has more iterations,
-			// select will choose a random case. double check if we need to stop
 			trace.Event("Received work (%v) from Channel 'doWork' iteration (%v)", worker, iteration)
-			select {
-			case <-stop:
-				return
-			default:
-			}
 			atomic.AddInt32(&r.busyWorkers, 1)
 			for _, stage := range r.activeScenario.Stages {
 				err := r.activeScenario.Run(metrics.IterationResult, stage.Name, worker, fmt.Sprint(iteration), stage.RunFn)

--- a/pkg/f1/testing/cancellable_timer.go
+++ b/pkg/f1/testing/cancellable_timer.go
@@ -47,11 +47,13 @@ func (c *CancellableTimer) wait() {
 }
 
 // Cancel makes all the waiters receive false
-func (c *CancellableTimer) Cancel() {
+func (c *CancellableTimer) Cancel() bool {
 	trace.Event("Closing Channel 'cancel'")
 	if atomic.CompareAndSwapInt32(&c.cancelled, 0, 1) {
 		close(c.cancel)
+		return true
 	}
+	return false
 }
 
 func (c *CancellableTimer) Reset(duration time.Duration) {

--- a/pkg/f1/trace/trace.go
+++ b/pkg/f1/trace/trace.go
@@ -1,0 +1,68 @@
+package trace
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+)
+
+var reset = "\033[0m"
+var gray = "\033[37m"
+var yellow = "\033[33m"
+var blue = "\033[34m"
+var red = "\033[31m"
+
+func colorString(s string, c string) string {
+	return c + s + reset
+}
+
+func ReceivedFromChannel(name string) {
+	event("Received from Channel '%s'", name)
+}
+
+func SentToChannel(name string) {
+	event("Sent to Channel '%s'", name)
+}
+
+func SendingToChannel(name string) {
+	event("Sending to Channel '%s'", name)
+}
+
+func Event(message string, args ...interface{}) {
+	event(message, args...)
+}
+
+func event(message string, args ...interface{}) {
+	if os.Getenv("TRACE") != "true" {
+		return
+	}
+
+	pc := make([]uintptr, 15)
+	n := runtime.Callers(3, pc)
+	frames := runtime.CallersFrames(pc[:n])
+	frame, _ := frames.Next()
+
+	keywords := []string{"channel", "Channel"}
+
+	fMessage := colorString(fmt.Sprintf(message, args...), yellow)
+
+	for _, s := range keywords {
+		fMessage = strings.Replace(fMessage, s, red+s+yellow, 1)
+	}
+
+	fileName := strings.Replace(frame.File, os.Getenv("GOPATH")+"/src/github.com/form3tech/k6-tests", ".", 1)
+	fileName = fmt.Sprintf("%s:%d", fileName, frame.Line)
+	fileName = colorString(fileName, blue)
+
+	t := time.Now()
+	formattedTime := fmt.Sprintf("%02d:%02d:%02d %02dms",
+		t.Hour(), t.Minute(), t.Second(), t.Nanosecond()/int(time.Millisecond))
+
+	timePart := colorString(fmt.Sprintf("[TRACE - %s]: ", formattedTime), gray)
+	messagePart := colorString(fmt.Sprintf("%s -> ", fMessage), gray)
+	filePart := colorString(fileName, blue)
+
+	fmt.Println(timePart + messagePart + filePart)
+}

--- a/pkg/f1/trigger/api/iteration_worker.go
+++ b/pkg/f1/trigger/api/iteration_worker.go
@@ -3,15 +3,17 @@ package api
 import (
 	"time"
 
+	"github.com/form3tech-oss/f1/pkg/f1/trace"
+
 	"github.com/form3tech-oss/f1/pkg/f1/options"
 )
 
 // NewIterationWorker produces a WorkTriggerer which triggers work at fixed intervals.
 func NewIterationWorker(iterationDuration time.Duration, rate RateFunction) WorkTriggerer {
-	return func(doWork chan<- bool, stop <-chan bool, workDone <-chan bool, options options.RunOptions) {
+	return func(workTriggered chan<- bool, stop <-chan bool, workDone <-chan bool, options options.RunOptions) {
 		startRate := rate(time.Now())
 		for i := 0; i < startRate; i++ {
-			doWork <- true
+			workTriggered <- true
 		}
 
 		// start ticker to trigger subsequent iterations.
@@ -24,12 +26,25 @@ func NewIterationWorker(iterationDuration time.Duration, rate RateFunction) Work
 				case <-workDone:
 					continue
 				case <-stop:
+					trace.ReceivedFromChannel("stop")
 					iterationTicker.Stop()
+					trace.Event("Iteration worker stopped.")
 					return
 				case start := <-iterationTicker.C:
+					// if both stop and the ticker are available at the same time
+					// a `case` will be chosen at random.
+					// double check the stop ch, continue to select again,
+					// and expect its own handler to be called
+					select {
+					case <-stop:
+						continue
+					default:
+					}
+
 					iterationRate := rate(start)
 					for i := 0; i < iterationRate; i++ {
-						doWork <- true
+						trace.SendingToChannel("workTriggered")
+						workTriggered <- true
 					}
 				}
 			}

--- a/pkg/f1/trigger/users/users_rate.go
+++ b/pkg/f1/trigger/users/users_rate.go
@@ -16,16 +16,16 @@ func UsersRate() api.Builder {
 		Description: "triggers test iterations from a static set of virtual users controlled by the --concurrency flag",
 		Flags:       flags,
 		New: func(params *pflag.FlagSet) (*api.Trigger, error) {
-			trigger := func(doWork chan<- bool, stop <-chan bool, workDone <-chan bool, options options.RunOptions) {
+			trigger := func(workTriggered chan<- bool, stop <-chan bool, workDone <-chan bool, options options.RunOptions) {
 				for i := 0; i < options.Concurrency; i++ {
-					doWork <- true
+					workTriggered <- true
 				}
 				for {
 					select {
 					case <-stop:
 						return
 					case <-workDone:
-						doWork <- true
+						workTriggered <- true
 					}
 				}
 			}


### PR DESCRIPTION
This commit was created with the changes in
https://github.com/form3tech/k6-tests/pull/505

What is this for?

This change fixes a bug that we had with the
TestParameterised:LimitedIterationsTest which was not returning the
correct iteration when completing. see
https://github.com/form3tech/k6-tests/issues/477

What has changed?

* There was a race condition with the CancellableTimer where it would
block on cancel. Also a panic was being masked when cancel was being
called more than once and the channel being closed. The blocking was
fixed by moving the CancellableTimer channel receive read to a go
routine that blocks and waits for a send on the channel.

* Also added detailed tracing so that it is easier to debug these
issues in the future. It can be turned on by setting an environment
variable TRACING=true.

Closes https://github.com/form3tech/f1-tests/issues/7