### PR TITLE
Rate distribution for multiple trigger modes

### DIFF
--- a/pkg/f1/run/run_cmd_test.go
+++ b/pkg/f1/run/run_cmd_test.go
@@ -95,6 +95,7 @@ func TestParameterised(t *testing.T) {
 			iterationDuration:      2 * time.Second,
 			expectedRunTime:        2 * time.Second,
 			expectedCompletedTests: 1,
+			distributionType:       "none",
 		},
 		{
 			name:                   "next iteration can start if previous still running",
@@ -104,6 +105,7 @@ func TestParameterised(t *testing.T) {
 			iterationDuration:      2 * time.Second,
 			expectedRunTime:        3 * time.Second,
 			expectedCompletedTests: 20,
+			distributionType:       "none",
 		},
 		{
 			name:                      "next iteration won't start if previous still running and limited by concurrency",
@@ -115,6 +117,7 @@ func TestParameterised(t *testing.T) {
 			iterationDuration:         2 * time.Second,
 			expectedDroppedIterations: 10,
 			expectedFailure:           true,
+			distributionType:          "none",
 		},
 		{
 			name:                   "limited iterations",
@@ -339,7 +342,8 @@ func TestRunScenarioThatFailsOccasionally(t *testing.T) {
 		a_rate_of("100/1s").and().
 		// Run less than 1 second, since if we run exactly for 1 second the test might run into another iteration.
 		// This would then lead to 200 requests being made, making the test fail
-		a_duration_of(500 * time.Millisecond)
+		a_duration_of(500 * time.Millisecond).and().
+		a_distribution_type("none")
 
 	when.i_execute_the_run_command()
 
@@ -354,7 +358,8 @@ func TestInterruptedRun(t *testing.T) {
 	given.
 		a_rate_of("5/10ms").and().
 		a_duration_of(5 * time.Second).and().
-		a_scenario_where_each_iteration_takes(0 * time.Second)
+		a_scenario_where_each_iteration_takes(0 * time.Second).and().
+		a_distribution_type("none")
 
 	when.the_test_run_is_started().and().
 		the_test_run_is_interrupted()
@@ -402,7 +407,8 @@ func TestFailureCounts(t *testing.T) {
 	given.
 		a_rate_of("10/s").and().
 		a_duration_of(500 * time.Millisecond).and().
-		a_test_scenario_that_fails_intermittently()
+		a_test_scenario_that_fails_intermittently().and().
+		a_distribution_type("none")
 
 	when.i_execute_the_run_command()
 

--- a/pkg/f1/run/run_cmd_test.go
+++ b/pkg/f1/run/run_cmd_test.go
@@ -290,7 +290,7 @@ func TestNoneDistribution(t *testing.T) {
 	when.i_start_a_timer().and().
 		i_execute_the_run_command()
 
-	then.there_should_be_x_requests_sent_over_y_intervals_of_x_ms(10, 1, 1000)
+	then.there_should_be_x_requests_sent_over_y_intervals_of_z_ms(10, 1, 1000)
 }
 
 func TestRegularDistribution(t *testing.T) {
@@ -308,7 +308,7 @@ func TestRegularDistribution(t *testing.T) {
 	when.i_start_a_timer().and().
 		i_execute_the_run_command()
 
-	then.there_should_be_x_requests_sent_over_y_intervals_of_x_ms(1, 5, 100)
+	then.there_should_be_x_requests_sent_over_y_intervals_of_z_ms(1, 5, 100)
 }
 
 func TestRandomDistribution(t *testing.T) {

--- a/pkg/f1/run/run_cmd_test.go
+++ b/pkg/f1/run/run_cmd_test.go
@@ -11,14 +11,13 @@ func TestSimpleFlow(t *testing.T) {
 	given, when, then := NewRunTestStage(t)
 
 	test := TestParam{
-		name:                   "simple staged test",
-		triggerType:            Staged,
-		stages:                 "0ms:0, 50ms: 100, 100ms: 100, 50ms:0",
-		iterationFrequency:     "100ms",
-		testDuration:           200 * time.Millisecond,
+		name:                   "basic test",
+		constantRate:           "10/100ms",
+		testDuration:           100 * time.Millisecond,
 		concurrency:            100,
-		iterationDuration:      1 * time.Millisecond,
-		expectedCompletedTests: 100,
+		iterationDuration:      100 * time.Millisecond,
+		expectedRunTime:        100 * time.Millisecond,
+		expectedCompletedTests: 10,
 	}
 	given.
 		a_trigger_type_of(test.triggerType).and().
@@ -274,6 +273,60 @@ func TestParameterised(t *testing.T) {
 				teardown_is_called_once()
 		})
 	}
+}
+
+func TestNoneDistribution(t *testing.T) {
+	given, when, then := NewRunTestStage(t)
+
+	given.
+		a_trigger_type_of(Constant).and().
+		a_rate_of("10/s").and().
+		a_distribution_type("none").and().
+		a_duration_of(500 * time.Millisecond).and().
+		a_concurrency_of(50).and().
+		an_iteration_limit_of(1000).and().
+		a_scenario_where_each_iteration_takes(1 * time.Millisecond)
+
+	when.i_start_a_timer().and().
+		i_execute_the_run_command()
+
+	then.there_should_be_x_requests_sent_over_y_intervals_of_x_ms(10, 1, 1000)
+}
+
+func TestRegularDistribution(t *testing.T) {
+	given, when, then := NewRunTestStage(t)
+
+	given.
+		a_trigger_type_of(Constant).and().
+		a_rate_of("10/s").and().
+		a_distribution_type("regular").and().
+		a_duration_of(500 * time.Millisecond).and().
+		a_concurrency_of(50).and().
+		an_iteration_limit_of(1000).and().
+		a_scenario_where_each_iteration_takes(1 * time.Millisecond)
+
+	when.i_start_a_timer().and().
+		i_execute_the_run_command()
+
+	then.there_should_be_x_requests_sent_over_y_intervals_of_x_ms(1, 5, 100)
+}
+
+func TestRandomDistribution(t *testing.T) {
+	given, when, then := NewRunTestStage(t)
+
+	given.
+		a_trigger_type_of(Constant).and().
+		a_rate_of("10/s").and().
+		a_distribution_type("random").and().
+		a_duration_of(500 * time.Millisecond).and().
+		a_concurrency_of(50).and().
+		an_iteration_limit_of(1000).and().
+		a_scenario_where_each_iteration_takes(1 * time.Millisecond)
+
+	when.i_start_a_timer().and().
+		i_execute_the_run_command()
+
+	then.the_requests_are_not_sent_all_at_once()
 }
 
 func TestRunScenarioThatFailsSetup(t *testing.T) {

--- a/pkg/f1/run/run_cmd_test.go
+++ b/pkg/f1/run/run_cmd_test.go
@@ -25,6 +25,7 @@ func TestSimpleFlow(t *testing.T) {
 		a_rate_of(test.constantRate).and().
 		a_stage_of(test.stages).and().
 		an_iteration_frequency_of(test.iterationFrequency).and().
+		a_distribution_type(test.distributionType).and().
 		a_duration_of(test.testDuration).and().
 		a_concurrency_of(test.concurrency).and().
 		an_iteration_limit_of(test.maxIterations).and().
@@ -63,6 +64,7 @@ type TestParam struct {
 	maxIterations             int32
 	stages                    string
 	iterationFrequency        string
+	distributionType          string
 }
 
 func TestParameterised(t *testing.T) {
@@ -134,6 +136,36 @@ func TestParameterised(t *testing.T) {
 			expectedCompletedTests: 17,
 		},
 		{
+			name:                   "regular distribution of a constant rate",
+			constantRate:           "10/s",
+			testDuration:           2 * time.Second,
+			concurrency:            100,
+			iterationDuration:      1 * time.Millisecond,
+			expectedRunTime:        2 * time.Second,
+			expectedCompletedTests: 20,
+			distributionType:       "regular",
+		},
+		{
+			name:                   "random distribution of a constant rate",
+			constantRate:           "10/s",
+			testDuration:           2 * time.Second,
+			concurrency:            100,
+			iterationDuration:      1 * time.Millisecond,
+			expectedRunTime:        2 * time.Second,
+			expectedCompletedTests: 20,
+			distributionType:       "random",
+		},
+		{
+			name:                   "run only half of requests on half of the time using regular distribution",
+			constantRate:           "10/2s",
+			testDuration:           1 * time.Second,
+			concurrency:            100,
+			iterationDuration:      1 * time.Millisecond,
+			expectedRunTime:        1 * time.Second,
+			expectedCompletedTests: 5,
+			distributionType:       "regular",
+		},
+		{
 			name:                   "simple staged test",
 			triggerType:            Staged,
 			stages:                 "0ms:0, 50ms: 100, 100ms: 100, 50ms:0",
@@ -152,6 +184,39 @@ func TestParameterised(t *testing.T) {
 			concurrency:            100,
 			iterationDuration:      1 * time.Millisecond,
 			expectedCompletedTests: 23,
+		},
+		{
+			name:                   "regular distribution of a staged trigger",
+			triggerType:            Staged,
+			stages:                 "0ms:0, 50ms: 100, 100ms: 100, 50ms:0",
+			iterationFrequency:     "100ms",
+			testDuration:           200 * time.Millisecond,
+			concurrency:            100,
+			iterationDuration:      1 * time.Millisecond,
+			expectedCompletedTests: 100,
+			distributionType:       "regular",
+		},
+		{
+			name:                   "random distribution of a staged trigger",
+			triggerType:            Staged,
+			stages:                 "0ms:0, 50ms: 100, 100ms: 100, 50ms:0",
+			iterationFrequency:     "100ms",
+			testDuration:           200 * time.Millisecond,
+			concurrency:            100,
+			iterationDuration:      1 * time.Millisecond,
+			expectedCompletedTests: 100,
+			distributionType:       "random",
+		},
+		{
+			name:                   "run half of requests on half of the time on staged test using regular distribution",
+			triggerType:            Staged,
+			stages:                 "0ms:0, 4s: 100",
+			iterationFrequency:     "1s",
+			testDuration:           3500 * time.Millisecond,
+			concurrency:            100,
+			iterationDuration:      1 * time.Millisecond,
+			expectedCompletedTests: 112,
+			distributionType:       "regular",
 		},
 		{
 			name:                   "users test slow iterations",
@@ -189,6 +254,7 @@ func TestParameterised(t *testing.T) {
 				a_rate_of(test.constantRate).and().
 				a_stage_of(test.stages).and().
 				an_iteration_frequency_of(test.iterationFrequency).and().
+				a_distribution_type(test.distributionType).and().
 				a_duration_of(test.testDuration).and().
 				a_concurrency_of(test.concurrency).and().
 				an_iteration_limit_of(test.maxIterations).and().

--- a/pkg/f1/run/run_stage_test.go
+++ b/pkg/f1/run/run_stage_test.go
@@ -70,8 +70,9 @@ func (s *RunTestStage) and() *RunTestStage {
 	return s
 }
 
+// Set the test duration 10ms earlier to avoid potential unwanted iterations and have flaky tests
 func (s *RunTestStage) a_duration_of(i time.Duration) *RunTestStage {
-	s.duration = i
+	s.duration = i - 10*time.Millisecond
 	return s
 }
 

--- a/pkg/f1/run/run_stage_test.go
+++ b/pkg/f1/run/run_stage_test.go
@@ -187,7 +187,7 @@ func (s *RunTestStage) a_scenario_where_each_iteration_takes(duration time.Durat
 		s.runCount = 0
 		return func(t *f1_testing.T) {
 				atomic.AddInt32(&s.runCount, 1)
-				s.durations.Store(time.Now(), time.Now().Sub(s.startTime))
+				s.durations.Store(time.Now(), time.Since(s.startTime))
 				time.Sleep(duration)
 			}, func(t *f1_testing.T) {
 				atomic.AddInt32(s.tearDownCount, 1)

--- a/pkg/f1/run/run_stage_test.go
+++ b/pkg/f1/run/run_stage_test.go
@@ -30,21 +30,22 @@ import (
 )
 
 type RunTestStage struct {
-	duration      time.Duration
-	runCount      int32
-	startTime     time.Time
-	t             *testing.T
-	scenario      string
-	runResult     *RunResult
-	concurrency   int
-	tearDownCount *int32
-	assert        *assert.Assertions
-	rate          string
-	maxIterations int32
-	triggerType   TriggerType
-	stages        string
-	frequency     string
-	require       *require.Assertions
+	duration         time.Duration
+	runCount         int32
+	startTime        time.Time
+	t                *testing.T
+	scenario         string
+	runResult        *RunResult
+	concurrency      int
+	tearDownCount    *int32
+	assert           *assert.Assertions
+	rate             string
+	maxIterations    int32
+	triggerType      TriggerType
+	stages           string
+	frequency        string
+	require          *require.Assertions
+	distributionType string
 }
 
 func NewRunTestStage(t *testing.T) (*RunTestStage, *RunTestStage, *RunTestStage) {
@@ -266,6 +267,11 @@ func (s *RunTestStage) build_trigger() *api.Trigger {
 		err = flags.Set("rate", s.rate)
 		require.NoError(s.t, err)
 
+		if s.distributionType != "" {
+			err = flags.Set("distribution", s.distributionType)
+			require.NoError(s.t, err)
+		}
+
 		t, err = constant.ConstantRate().New(flags)
 		require.NoError(s.t, err)
 	} else if s.triggerType == Staged {
@@ -276,6 +282,11 @@ func (s *RunTestStage) build_trigger() *api.Trigger {
 
 		err = flags.Set("iterationFrequency", s.frequency)
 		require.NoError(s.t, err)
+
+		if s.distributionType != "" {
+			err = flags.Set("distribution", s.distributionType)
+			require.NoError(s.t, err)
+		}
 
 		t, err = staged.StagedRate().New(flags)
 		require.Nil(s.t, err)
@@ -317,6 +328,11 @@ func (s *RunTestStage) a_stage_of(stages string) *RunTestStage {
 
 func (s *RunTestStage) an_iteration_frequency_of(frequency string) *RunTestStage {
 	s.frequency = frequency
+	return s
+}
+
+func (s *RunTestStage) a_distribution_type(distributionType string) *RunTestStage {
+	s.distributionType = distributionType
 	return s
 }
 

--- a/pkg/f1/run/run_stage_test.go
+++ b/pkg/f1/run/run_stage_test.go
@@ -239,7 +239,7 @@ func (s *RunTestStage) distribution_duration_map_of_requests() map[time.Duration
 	distributionMap := make(map[time.Duration]int32)
 	s.durations.Range(func(key, value interface{}) bool {
 		requestDuration := value.(time.Duration)
-		truncatedDuration := requestDuration.Truncate(20 * time.Millisecond)
+		truncatedDuration := requestDuration.Truncate(100 * time.Millisecond)
 		existingDuration := distributionMap[truncatedDuration] + 1
 		distributionMap[truncatedDuration] = existingDuration
 		return true

--- a/pkg/f1/run/run_stage_test.go
+++ b/pkg/f1/run/run_stage_test.go
@@ -248,7 +248,7 @@ func (s *RunTestStage) distribution_duration_map_of_requests() map[time.Duration
 	return distributionMap
 }
 
-func (s *RunTestStage) there_should_be_x_requests_sent_over_y_intervals_of_x_ms(requests, intervals, ms int) *RunTestStage {
+func (s *RunTestStage) there_should_be_x_requests_sent_over_y_intervals_of_z_ms(requests, intervals, ms int) *RunTestStage {
 	expectedDistribution := map[time.Duration]int32{}
 	for i := 0; i < intervals; i++ {
 		key := time.Duration(i) * time.Duration(ms) * time.Millisecond

--- a/pkg/f1/run/run_stage_test.go
+++ b/pkg/f1/run/run_stage_test.go
@@ -70,9 +70,8 @@ func (s *RunTestStage) and() *RunTestStage {
 	return s
 }
 
-// Set the test duration 10ms earlier to avoid potential unwanted iterations and have flaky tests
 func (s *RunTestStage) a_duration_of(i time.Duration) *RunTestStage {
-	s.duration = i - 10*time.Millisecond
+	s.duration = i
 	return s
 }
 

--- a/pkg/f1/run/test_runner.go
+++ b/pkg/f1/run/test_runner.go
@@ -183,7 +183,7 @@ func (r *Run) run() {
 	}
 
 	// Cancel work slightly before end of duration to avoid starting a new iteration
-	durationElapsed := testing.NewCancellableTimer(duration - 5*time.Millisecond)
+	durationElapsed := testing.NewCancellableTimer(duration - 10*time.Millisecond)
 	r.result.RecordStarted()
 	defer r.result.RecordTestFinished()
 

--- a/pkg/f1/trigger/api/iteration_distribution.go
+++ b/pkg/f1/trigger/api/iteration_distribution.go
@@ -65,6 +65,10 @@ func WithRandomDistribution(iterationDuration time.Duration, rateFn RateFunction
 			currentRate = remainingRate
 		} else {
 			currentRate = randFn(remainingRate)
+
+			if currentRate > remainingRate {
+				currentRate = remainingRate
+			}
 		}
 		remainingRate -= currentRate
 		remainingSteps--

--- a/pkg/f1/trigger/api/iteration_distribution.go
+++ b/pkg/f1/trigger/api/iteration_distribution.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"math"
+	"time"
+)
+
+// WithConstantDistribution distributes the rate constantly across 100ms intervals
+func WithConstantDistribution(iterationDuration time.Duration, rateFn RateFunction) (time.Duration, RateFunction) {
+	distributedIterationDuration := 100 * time.Millisecond
+
+	if iterationDuration < distributedIterationDuration {
+		return iterationDuration, rateFn
+	}
+
+	rate := 0
+	accRate := 0.0
+	remainingSteps := 0
+	tickSteps := int(iterationDuration.Milliseconds() / distributedIterationDuration.Milliseconds())
+
+	distributedRateFn := func(time time.Time) int {
+		if remainingSteps == 0 {
+			rate = rateFn(time)
+			accRate = 0.0
+			remainingSteps = tickSteps
+		}
+
+		accRate += float64(rate) / float64(tickSteps)
+		accRate = math.Round(accRate*10_000_000) / 10_000_000
+		remainingSteps--
+
+		if accRate < 1 {
+			return 0
+		}
+
+		roundedAccRate := int(accRate)
+		accRate -= float64(roundedAccRate)
+
+		return roundedAccRate
+	}
+
+	return distributedIterationDuration, distributedRateFn
+}

--- a/pkg/f1/trigger/api/iteration_distribution.go
+++ b/pkg/f1/trigger/api/iteration_distribution.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-// WithConstantDistribution distributes the rate constantly across 100ms intervals
-func WithConstantDistribution(iterationDuration time.Duration, rateFn RateFunction) (time.Duration, RateFunction) {
+// WithRegularDistribution distributes the rate constantly across 100ms intervals
+func WithRegularDistribution(iterationDuration time.Duration, rateFn RateFunction) (time.Duration, RateFunction) {
 	distributedIterationDuration := 100 * time.Millisecond
 
 	if iterationDuration < distributedIterationDuration {

--- a/pkg/f1/trigger/api/iteration_distribution_test.go
+++ b/pkg/f1/trigger/api/iteration_distribution_test.go
@@ -61,6 +61,11 @@ func TestRegularRateDistribution(t *testing.T) {
 		},
 		{
 			iterationDuration:        1 * time.Second,
+			rate:                     25,
+			expectedDistributedRates: []int{2, 3, 2, 3, 2, 3, 2, 3, 2, 3},
+		},
+		{
+			iterationDuration:        1 * time.Second,
 			rate:                     100,
 			expectedDistributedRates: []int{10, 10, 10, 10, 10, 10, 10, 10, 10, 10},
 		},
@@ -123,7 +128,7 @@ func TestRegularRateDistribution(t *testing.T) {
 		t.Run(fmt.Sprintf("%d: iteration duration %s, rate %d", i, test.iterationDuration, test.rate), func(t *testing.T) {
 			rateFn := func(time time.Time) int { return test.rate }
 
-			distributedIterationDuration, distributedRate := WithRegularDistribution(test.iterationDuration, rateFn)
+			distributedIterationDuration, distributedRate := withRegularDistribution(test.iterationDuration, rateFn)
 			var result []int
 			for i := 0; i < len(test.expectedDistributedRates); i++ {
 				result = append(result, distributedRate(time.Now()))
@@ -139,7 +144,7 @@ func TestRegularRateDistributionWithSmallIterationDuration(t *testing.T) {
 	iterationDuration := 10 * time.Millisecond
 	rateFn := func(time time.Time) int { return 10_000 }
 
-	distributedIterationDuration, distributedRate := WithRegularDistribution(iterationDuration, rateFn)
+	distributedIterationDuration, distributedRate := withRegularDistribution(iterationDuration, rateFn)
 
 	require.Equal(t, 10*time.Millisecond, distributedIterationDuration)
 	require.Equal(t, 10_000, distributedRate(time.Now()))
@@ -157,7 +162,7 @@ func TestRegularRateDistributionWithVariableRate(t *testing.T) {
 		0, 1, 1, 1, 1, 0, 1, 1, 1, 1,
 	}
 
-	distributedIterationDuration, distributedRate := WithRegularDistribution(iterationDuration, rateFn)
+	distributedIterationDuration, distributedRate := withRegularDistribution(iterationDuration, rateFn)
 	var result []int
 	for i := 0; i < len(expectedDistributedRates); i++ {
 		result = append(result, distributedRate(time.Now()))
@@ -222,7 +227,7 @@ func TestRandomRateDistribution(t *testing.T) {
 			var idx = -1
 			randFn := func(limit int) int { idx++; return test.randomValues[idx] }
 
-			distributedIterationDuration, distributedRate := WithRandomDistribution(test.iterationDuration, rateFn, randFn)
+			distributedIterationDuration, distributedRate := withRandomDistribution(test.iterationDuration, rateFn, randFn)
 			var result []int
 			for i := 0; i < len(test.expectedDistributedRates); i++ {
 				result = append(result, distributedRate(time.Now()))
@@ -254,7 +259,7 @@ func TestRandomRateDistributionWithVariableRate(t *testing.T) {
 		0, 1, 1, 1, 1, 0, 1, 1, 1, 1,
 	}
 
-	distributedIterationDuration, distributedRate := WithRandomDistribution(iterationDuration, rateFn, randFn)
+	distributedIterationDuration, distributedRate := withRandomDistribution(iterationDuration, rateFn, randFn)
 	var result []int
 	for i := 0; i < len(expectedDistributedRates); i++ {
 		result = append(result, distributedRate(time.Now()))

--- a/pkg/f1/trigger/api/iteration_distribution_test.go
+++ b/pkg/f1/trigger/api/iteration_distribution_test.go
@@ -1,0 +1,184 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstantRateDistribution(t *testing.T) {
+	for i, test := range []struct {
+		iterationDuration           time.Duration
+		rate                        int
+		expectedDistributedDuration time.Duration
+		expectedDistributedRates    []int
+		expectedDistributedSteps    int
+	}{
+		{
+			iterationDuration:        100 * time.Millisecond,
+			rate:                     1,
+			expectedDistributedRates: []int{1},
+		},
+		{
+			iterationDuration:        100 * time.Millisecond,
+			rate:                     10,
+			expectedDistributedRates: []int{10},
+		},
+		{
+			iterationDuration:        200 * time.Millisecond,
+			rate:                     10,
+			expectedDistributedRates: []int{5, 5},
+		},
+		{
+			iterationDuration:        900 * time.Millisecond,
+			rate:                     7,
+			expectedDistributedRates: []int{0, 1, 1, 1, 0, 1, 1, 1, 1},
+		},
+		{
+			iterationDuration:        1 * time.Second,
+			rate:                     1,
+			expectedDistributedRates: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		},
+		{
+			iterationDuration:        1 * time.Second,
+			rate:                     5,
+			expectedDistributedRates: []int{0, 1, 0, 1, 0, 1, 0, 1, 0, 1},
+		},
+		{
+			iterationDuration:        1 * time.Second,
+			rate:                     7,
+			expectedDistributedRates: []int{0, 1, 1, 0, 1, 1, 0, 1, 1, 1},
+		},
+		{
+			iterationDuration:        1 * time.Second,
+			rate:                     10,
+			expectedDistributedRates: []int{1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+		},
+		{
+			iterationDuration:        1 * time.Second,
+			rate:                     15,
+			expectedDistributedRates: []int{1, 2, 1, 2, 1, 2, 1, 2, 1, 2},
+		},
+		{
+			iterationDuration:        1 * time.Second,
+			rate:                     100,
+			expectedDistributedRates: []int{10, 10, 10, 10, 10, 10, 10, 10, 10, 10},
+		},
+		{
+			iterationDuration:        1 * time.Second,
+			rate:                     200,
+			expectedDistributedRates: []int{20, 20, 20, 20, 20, 20, 20, 20, 20, 20},
+		},
+		{
+			iterationDuration:        2 * time.Second,
+			rate:                     10,
+			expectedDistributedRates: repeatSlice([]int{0, 1, 0, 1, 0, 1, 0, 1, 0, 1}, 2),
+		},
+		{
+			iterationDuration:        2 * time.Second,
+			rate:                     100,
+			expectedDistributedRates: repeatSlice([]int{5, 5, 5, 5, 5, 5, 5, 5, 5, 5}, 2),
+		},
+		{
+			iterationDuration:        1 * time.Minute,
+			rate:                     60,
+			expectedDistributedRates: repeatSlice([]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 60),
+		},
+		{
+			iterationDuration:        10 * time.Minute,
+			rate:                     10,
+			expectedDistributedRates: repeatSlice(append(repeatValue(0, 599), 1), 10),
+		},
+		{
+			iterationDuration:        1 * time.Minute,
+			rate:                     600,
+			expectedDistributedRates: repeatSlice([]int{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 600),
+		},
+		{
+			iterationDuration:        1 * time.Minute,
+			rate:                     6_000,
+			expectedDistributedRates: repeatSlice([]int{10, 10, 10, 10, 10, 10, 10, 10, 10, 10}, 600),
+		},
+		{
+			iterationDuration:        1 * time.Hour,
+			rate:                     3_600,
+			expectedDistributedRates: repeatSlice([]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 3_600),
+		},
+		{
+			iterationDuration:        1 * time.Hour,
+			rate:                     36_000,
+			expectedDistributedRates: repeatSlice([]int{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 3_600),
+		},
+		{
+			iterationDuration:        1 * time.Hour,
+			rate:                     360_000,
+			expectedDistributedRates: repeatSlice([]int{10, 10, 10, 10, 10, 10, 10, 10, 10, 10}, 3_600),
+		},
+		{
+			iterationDuration:        100 * time.Second,
+			rate:                     900,
+			expectedDistributedRates: repeatSlice([]int{0, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 100),
+		},
+	} {
+		t.Run(fmt.Sprintf("%d: iteration duration %s, rate %d", i, test.iterationDuration, test.rate), func(t *testing.T) {
+			rateFn := func(time time.Time) int { return test.rate }
+
+			distributedIterationDuration, distributedRate := WithConstantDistribution(test.iterationDuration, rateFn)
+			var result []int
+			for i := 0; i < len(test.expectedDistributedRates); i++ {
+				result = append(result, distributedRate(time.Now()))
+			}
+
+			require.Equal(t, 100*time.Millisecond, distributedIterationDuration)
+			require.Equal(t, test.expectedDistributedRates, result)
+		})
+	}
+}
+
+func TestConstantRateDistributionWithSmallIterationDuration(t *testing.T) {
+	iterationDuration := 10 * time.Millisecond
+	rateFn := func(time time.Time) int { return 10_000 }
+
+	distributedIterationDuration, distributedRate := WithConstantDistribution(iterationDuration, rateFn)
+
+	require.Equal(t, 10*time.Millisecond, distributedIterationDuration)
+	require.Equal(t, 10_000, distributedRate(time.Now()))
+}
+
+func TestConstantRateDistributionWithVariableRate(t *testing.T) {
+	iterationDuration := 1 * time.Second
+	rates := []int{5, 15, 12, 8}
+	var idx = -1
+	rateFn := func(time time.Time) int { idx++; return rates[idx] }
+	expectedDistributedRates := []int{
+		0, 1, 0, 1, 0, 1, 0, 1, 0, 1,
+		1, 2, 1, 2, 1, 2, 1, 2, 1, 2,
+		1, 1, 1, 1, 2, 1, 1, 1, 1, 2,
+		0, 1, 1, 1, 1, 0, 1, 1, 1, 1,
+	}
+
+	distributedIterationDuration, distributedRate := WithConstantDistribution(iterationDuration, rateFn)
+	var result []int
+	for i := 0; i < len(expectedDistributedRates); i++ {
+		result = append(result, distributedRate(time.Now()))
+	}
+
+	require.Equal(t, 100*time.Millisecond, distributedIterationDuration)
+	require.Equal(t, expectedDistributedRates, result)
+}
+
+func repeatSlice(arr []int, times int) []int {
+	var newArr []int
+
+	for i := 0; i < times; i++ {
+		newArr = append(newArr, arr...)
+	}
+
+	return newArr
+}
+
+func repeatValue(value int, times int) []int {
+	return repeatSlice([]int{value}, times)
+}

--- a/pkg/f1/trigger/api/iteration_distribution_test.go
+++ b/pkg/f1/trigger/api/iteration_distribution_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConstantRateDistribution(t *testing.T) {
+func TestRegularRateDistribution(t *testing.T) {
 	for i, test := range []struct {
 		iterationDuration        time.Duration
 		rate                     int
@@ -123,7 +123,7 @@ func TestConstantRateDistribution(t *testing.T) {
 		t.Run(fmt.Sprintf("%d: iteration duration %s, rate %d", i, test.iterationDuration, test.rate), func(t *testing.T) {
 			rateFn := func(time time.Time) int { return test.rate }
 
-			distributedIterationDuration, distributedRate := WithConstantDistribution(test.iterationDuration, rateFn)
+			distributedIterationDuration, distributedRate := WithRegularDistribution(test.iterationDuration, rateFn)
 			var result []int
 			for i := 0; i < len(test.expectedDistributedRates); i++ {
 				result = append(result, distributedRate(time.Now()))
@@ -135,17 +135,17 @@ func TestConstantRateDistribution(t *testing.T) {
 	}
 }
 
-func TestConstantRateDistributionWithSmallIterationDuration(t *testing.T) {
+func TestRegularRateDistributionWithSmallIterationDuration(t *testing.T) {
 	iterationDuration := 10 * time.Millisecond
 	rateFn := func(time time.Time) int { return 10_000 }
 
-	distributedIterationDuration, distributedRate := WithConstantDistribution(iterationDuration, rateFn)
+	distributedIterationDuration, distributedRate := WithRegularDistribution(iterationDuration, rateFn)
 
 	require.Equal(t, 10*time.Millisecond, distributedIterationDuration)
 	require.Equal(t, 10_000, distributedRate(time.Now()))
 }
 
-func TestConstantRateDistributionWithVariableRate(t *testing.T) {
+func TestRegularRateDistributionWithVariableRate(t *testing.T) {
 	iterationDuration := 1 * time.Second
 	rates := []int{5, 15, 12, 8}
 	var idx = -1
@@ -157,7 +157,7 @@ func TestConstantRateDistributionWithVariableRate(t *testing.T) {
 		0, 1, 1, 1, 1, 0, 1, 1, 1, 1,
 	}
 
-	distributedIterationDuration, distributedRate := WithConstantDistribution(iterationDuration, rateFn)
+	distributedIterationDuration, distributedRate := WithRegularDistribution(iterationDuration, rateFn)
 	var result []int
 	for i := 0; i < len(expectedDistributedRates); i++ {
 		result = append(result, distributedRate(time.Now()))

--- a/pkg/f1/trigger/constant/constant_rate.go
+++ b/pkg/f1/trigger/constant/constant_rate.go
@@ -76,7 +76,7 @@ func ConstantRate() api.Builder {
 
 			return &api.Trigger{
 					Trigger:     api.NewIterationWorker(distributedIterationDuration, distributedRateFn),
-					Description: fmt.Sprintf("%d iterations every %s", rate, distributedIterationDuration),
+					Description: fmt.Sprintf("%d iterations every %s, using distribution %s", rate, iterationDuration, distributionTypeArg),
 					DryRun:      distributedRateFn,
 				},
 				nil

--- a/pkg/f1/trigger/constant/constant_rate.go
+++ b/pkg/f1/trigger/constant/constant_rate.go
@@ -16,7 +16,7 @@ func ConstantRate() api.Builder {
 	flags := pflag.NewFlagSet("constant", pflag.ContinueOnError)
 	flags.StringP("rate", "r", "1/s", "number of iterations to start per interval, in the form <request>/<duration>")
 	flags.Float64P("jitter", "j", 0.0, "vary the rate randomly by up to jitter percent")
-	flags.String("distribution", "none", "optional parameter to distribute the rate over steps of 100ms, which can be none|regular|random")
+	flags.String("distribution", "regular", "optional parameter to distribute the rate over steps of 100ms, which can be none|regular|random")
 
 	return api.Builder{
 		Name:        "constant",

--- a/pkg/f1/trigger/constant/constant_rate.go
+++ b/pkg/f1/trigger/constant/constant_rate.go
@@ -71,7 +71,7 @@ func ConstantRate() api.Builder {
 				randomFn := func(limit int) int { return rand.Intn(limit) }
 				distributedIterationDuration, distributedRateFn = api.WithRandomDistribution(iterationDuration, rateFn, randomFn)
 			default:
-				return nil, fmt.Errorf("unable to parse distribution-type #{distributionTypeArg}")
+				return nil, fmt.Errorf("unable to parse distribution %s", distributionTypeArg)
 			}
 
 			return &api.Trigger{

--- a/pkg/f1/trigger/constant/constant_rate.go
+++ b/pkg/f1/trigger/constant/constant_rate.go
@@ -17,7 +17,7 @@ func ConstantRate() api.Builder {
 	flags := pflag.NewFlagSet("constant", pflag.ContinueOnError)
 	flags.StringP("rate", "r", "1/s", "number of iterations to start per interval, in the form <request>/<duration>")
 	flags.Float64P("jitter", "j", 0.0, "vary the rate randomly by up to jitter percent")
-	flags.String("distribution", "none", "optional parameter to distribute the rate over steps of 100ms")
+	flags.String("distribution", "none", "optional parameter to distribute the rate over steps of 100ms, which can be none|regular|random")
 
 	return api.Builder{
 		Name:        "constant",

--- a/pkg/f1/trigger/gaussian/gaussian_rate.go
+++ b/pkg/f1/trigger/gaussian/gaussian_rate.go
@@ -97,10 +97,18 @@ func GaussianRate() api.Builder {
 			}
 
 			return &api.Trigger{
-					Trigger:     api.NewIterationWorker(distributedIterationDuration, distributedRateFn),
-					DryRun:      distributedRateFn,
-					Description: fmt.Sprintf("Gaussian distribution triggering %d iterations per %s, peaking at %s with standard deviation of %s%s", int(volume), repeat, peak, stddev, jitterDesc),
-					Duration:    time.Hour * 24 * 356,
+					Trigger: api.NewIterationWorker(distributedIterationDuration, distributedRateFn),
+					DryRun:  distributedRateFn,
+					Description: fmt.Sprintf(
+						"Gaussian distribution triggering %d iterations per %s, peaking at %s with standard deviation of %s%s, using distribution %s",
+						int(volume),
+						repeat,
+						peak,
+						stddev,
+						jitterDesc,
+						distributionTypeArg,
+					),
+					Duration: time.Hour * 24 * 356,
 				},
 				nil
 		},

--- a/pkg/f1/trigger/gaussian/gaussian_rate.go
+++ b/pkg/f1/trigger/gaussian/gaussian_rate.go
@@ -22,7 +22,7 @@ func GaussianRate() api.Builder {
 	flags.Duration("peak", 14*time.Hour, "The offset within the repetition window when the load should reach its maximum. Default 14 hours (with 24 hour default repeat)")
 	flags.Duration("standard-deviation", 150*time.Minute, "The standard deviation to use for the distribution of load")
 	flags.Float64P("jitter", "j", 0.0, "vary the rate randomly by up to jitter percent")
-	flags.String("distribution", "none", "optional parameter to distribute the rate over steps of 100ms, which can be none|regular|random")
+	flags.String("distribution", "regular", "optional parameter to distribute the rate over steps of 100ms, which can be none|regular|random")
 
 	return api.Builder{
 		Name:        "gaussian",

--- a/pkg/f1/trigger/gaussian/gaussian_rate.go
+++ b/pkg/f1/trigger/gaussian/gaussian_rate.go
@@ -23,7 +23,7 @@ func GaussianRate() api.Builder {
 	flags.Duration("peak", 14*time.Hour, "The offset within the repetition window when the load should reach its maximum. Default 14 hours (with 24 hour default repeat)")
 	flags.Duration("standard-deviation", 150*time.Minute, "The standard deviation to use for the distribution of load")
 	flags.Float64P("jitter", "j", 0.0, "vary the rate randomly by up to jitter percent")
-	flags.String("distribution", "none", "optional parameter to distribute the rate over steps of 100ms")
+	flags.String("distribution", "none", "optional parameter to distribute the rate over steps of 100ms, which can be none|regular|random")
 
 	return api.Builder{
 		Name:        "gaussian",

--- a/pkg/f1/trigger/gaussian/gaussian_rate.go
+++ b/pkg/f1/trigger/gaussian/gaussian_rate.go
@@ -93,7 +93,7 @@ func GaussianRate() api.Builder {
 				randomFn := func(limit int) int { return rand.Intn(limit) }
 				distributedIterationDuration, distributedRateFn = api.WithRandomDistribution(frequency, rateFn, randomFn)
 			default:
-				return nil, fmt.Errorf("unable to parse distribution-type #{distributionTypeArg}")
+				return nil, fmt.Errorf("unable to parse distribution %s", distributionTypeArg)
 			}
 
 			return &api.Trigger{

--- a/pkg/f1/trigger/staged/staged_rate.go
+++ b/pkg/f1/trigger/staged/staged_rate.go
@@ -2,6 +2,7 @@ package staged
 
 import (
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/form3tech-oss/f1/pkg/f1/trigger/api"
@@ -14,6 +15,7 @@ func StagedRate() api.Builder {
 	flags.StringP("stages", "s", "0s:1, 10s:1", "Comma separated list of <stage_duration>:<target_concurrent_iterations>. During the stage, the number of concurrent iterations will ramp up or down to the target. ")
 	flags.DurationP("iterationFrequency", "f", 1*time.Second, "How frequently iterations should be started")
 	flags.Float64P("jitter", "j", 0.0, "vary the rate randomly by up to jitter percent")
+	flags.String("distribution", "none", "optional parameter to distribute the rate over steps of 100ms")
 
 	return api.Builder{
 		Name:        "staged",
@@ -33,6 +35,10 @@ func StagedRate() api.Builder {
 			if err != nil {
 				return nil, err
 			}
+			distributionTypeArg, err := params.GetString("distribution")
+			if err != nil {
+				return nil, err
+			}
 
 			stages, err := parseStages(stg)
 			if err != nil {
@@ -40,11 +46,26 @@ func StagedRate() api.Builder {
 			}
 
 			calculator := newRateCalculator(stages)
+			rateFn := api.WithJitter(calculator.Rate, jitterArg)
+
+			var distributedIterationDuration time.Duration
+			var distributedRateFn func(time time.Time) int
+			switch distributionTypeArg {
+			case "none":
+				distributedIterationDuration, distributedRateFn = frequency, rateFn
+			case "regular":
+				distributedIterationDuration, distributedRateFn = api.WithRegularDistribution(frequency, rateFn)
+			case "random":
+				randomFn := func(limit int) int { return rand.Intn(limit) }
+				distributedIterationDuration, distributedRateFn = api.WithRandomDistribution(frequency, rateFn, randomFn)
+			default:
+				return nil, fmt.Errorf("unable to parse distribution-type #{distributionTypeArg}")
+			}
 
 			return &api.Trigger{
-					Trigger:     api.NewIterationWorker(frequency, api.WithJitter(calculator.Rate, jitterArg)),
-					DryRun:      api.WithJitter(calculator.Rate, jitterArg),
-					Description: fmt.Sprintf("Starting iterations every %s in numbers varying by time: %s,", frequency, stg),
+					Trigger:     api.NewIterationWorker(distributedIterationDuration, distributedRateFn),
+					DryRun:      distributedRateFn,
+					Description: fmt.Sprintf("Starting iterations every %s in numbers varying by time: %s,", distributedIterationDuration, stg),
 					Duration:    calculator.MaxDuration(),
 				},
 				nil

--- a/pkg/f1/trigger/staged/staged_rate.go
+++ b/pkg/f1/trigger/staged/staged_rate.go
@@ -15,7 +15,7 @@ func StagedRate() api.Builder {
 	flags.StringP("stages", "s", "0s:1, 10s:1", "Comma separated list of <stage_duration>:<target_concurrent_iterations>. During the stage, the number of concurrent iterations will ramp up or down to the target. ")
 	flags.DurationP("iterationFrequency", "f", 1*time.Second, "How frequently iterations should be started")
 	flags.Float64P("jitter", "j", 0.0, "vary the rate randomly by up to jitter percent")
-	flags.String("distribution", "none", "optional parameter to distribute the rate over steps of 100ms")
+	flags.String("distribution", "none", "optional parameter to distribute the rate over steps of 100ms, which can be none|regular|random")
 
 	return api.Builder{
 		Name:        "staged",

--- a/pkg/f1/trigger/staged/staged_rate.go
+++ b/pkg/f1/trigger/staged/staged_rate.go
@@ -59,7 +59,7 @@ func StagedRate() api.Builder {
 				randomFn := func(limit int) int { return rand.Intn(limit) }
 				distributedIterationDuration, distributedRateFn = api.WithRandomDistribution(frequency, rateFn, randomFn)
 			default:
-				return nil, fmt.Errorf("unable to parse distribution-type #{distributionTypeArg}")
+				return nil, fmt.Errorf("unable to parse distribution %s", distributionTypeArg)
 			}
 
 			return &api.Trigger{

--- a/pkg/f1/trigger/staged/staged_rate.go
+++ b/pkg/f1/trigger/staged/staged_rate.go
@@ -65,7 +65,7 @@ func StagedRate() api.Builder {
 			return &api.Trigger{
 					Trigger:     api.NewIterationWorker(distributedIterationDuration, distributedRateFn),
 					DryRun:      distributedRateFn,
-					Description: fmt.Sprintf("Starting iterations every %s in numbers varying by time: %s,", distributedIterationDuration, stg),
+					Description: fmt.Sprintf("Starting iterations every %s in numbers varying by time: %s, using distribution %s", frequency, stg, distributionTypeArg),
 					Duration:    calculator.MaxDuration(),
 				},
 				nil

--- a/pkg/f1/trigger/staged/staged_rate.go
+++ b/pkg/f1/trigger/staged/staged_rate.go
@@ -14,7 +14,7 @@ func StagedRate() api.Builder {
 	flags.StringP("stages", "s", "0s:1, 10s:1", "Comma separated list of <stage_duration>:<target_concurrent_iterations>. During the stage, the number of concurrent iterations will ramp up or down to the target. ")
 	flags.DurationP("iterationFrequency", "f", 1*time.Second, "How frequently iterations should be started")
 	flags.Float64P("jitter", "j", 0.0, "vary the rate randomly by up to jitter percent")
-	flags.String("distribution", "none", "optional parameter to distribute the rate over steps of 100ms, which can be none|regular|random")
+	flags.String("distribution", "regular", "optional parameter to distribute the rate over steps of 100ms, which can be none|regular|random")
 
 	return api.Builder{
 		Name:        "staged",


### PR DESCRIPTION
Add different distribution modes for the constant, staged and gaussian triggers. The default distribution is regular.
The motivation of distributing the load is to be more effective when the request are resolved very fast.

- [x] Regular distribution - distribute the load evenly across intervals of 100ms.

- [x] Random distribution - distribute the load randomly across intervals of 100ms. The last interval of the iteration will compensate with the remaining load.

- [x] None distribution - the program will work the same as before without using any of the distribution modes.
