### PR TITLE
Reduce tests flakyness

### DIFF
--- a/pkg/f1/run/result.go
+++ b/pkg/f1/run/result.go
@@ -183,8 +183,6 @@ func (r *RunResult) Progress() string {
 }
 
 func (r *RunResult) Duration() time.Duration {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
 	return time.Since(r.StartTime())
 }
 
@@ -225,9 +223,6 @@ func (r *RunResult) IterationsStarted() uint64 {
 }
 
 func (r *RunResult) StartTime() time.Time {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
 	return r.startTime
 }
 

--- a/pkg/f1/run/test_runner.go
+++ b/pkg/f1/run/test_runner.go
@@ -183,7 +183,7 @@ func (r *Run) run() {
 	}
 
 	// Cancel work slightly before end of duration to avoid starting a new iteration
-	durationElapsed := testing.NewCancellableTimer(duration - 5*time.Millisecond)
+	durationElapsed := testing.NewCancellableTimer(duration - 10*time.Millisecond)
 	r.result.RecordStarted()
 	defer r.result.RecordTestFinished()
 

--- a/pkg/f1/run/test_runner.go
+++ b/pkg/f1/run/test_runner.go
@@ -183,7 +183,7 @@ func (r *Run) run() {
 	}
 
 	// Cancel work slightly before end of duration to avoid starting a new iteration
-	durationElapsed := testing.NewCancellableTimer(duration - 10*time.Millisecond)
+	durationElapsed := testing.NewCancellableTimer(duration - 5*time.Millisecond)
 	r.result.RecordStarted()
 	defer r.result.RecordTestFinished()
 

--- a/pkg/f1/trigger/api/iteration_distribution.go
+++ b/pkg/f1/trigger/api/iteration_distribution.go
@@ -26,7 +26,7 @@ func NewDistribution(distributionTypeArg string, iterationDuration time.Duration
 func withRegularDistribution(iterationDuration time.Duration, rateFn RateFunction) (time.Duration, RateFunction) {
 	distributedIterationDuration := 100 * time.Millisecond
 
-	if iterationDuration < distributedIterationDuration {
+	if iterationDuration <= distributedIterationDuration {
 		return iterationDuration, rateFn
 	}
 
@@ -62,7 +62,7 @@ func withRegularDistribution(iterationDuration time.Duration, rateFn RateFunctio
 func withRandomDistribution(iterationDuration time.Duration, rateFn RateFunction, randFn func(int) int) (time.Duration, RateFunction) {
 	distributedIterationDuration := 100 * time.Millisecond
 
-	if iterationDuration < distributedIterationDuration {
+	if iterationDuration <= distributedIterationDuration {
 		return iterationDuration, rateFn
 	}
 


### PR DESCRIPTION
- Remove unnecessary locker which can produce a dead-lock.
- Make distribution more optimal, when the iteration duration is 100ms there is no need to distribute.