### PR TITLE
reduce duplicate reporting of errors

### DIFF
--- a/pkg/f1/testing/t.go
+++ b/pkg/f1/testing/t.go
@@ -38,17 +38,24 @@ func NewT(env map[string]string, vu, iter string, scenarioName string) *T {
 }
 
 func (t *T) Errorf(format string, args ...interface{}) {
-	t.Fail()
+	atomic.StoreInt64(&t.failed, int64(1))
 	t.Log.Errorf(format, args...)
 }
 
 func (t *T) FailNow() {
-	t.Fail()
+	atomic.StoreInt64(&t.failed, int64(1))
+	t.Log.Errorf("test failed and stopped")
 	runtime.Goexit()
 }
 
 func (t *T) Fail() {
 	atomic.StoreInt64(&t.failed, int64(1))
+	t.Log.Errorf("test failed")
+}
+
+func (t *T) FailWithError(err error) {
+	atomic.StoreInt64(&t.failed, int64(1))
+	t.Log.WithError(err).Errorf("test failed due to %s", err.Error())
 }
 
 func (t *T) HasFailed() bool {


### PR DESCRIPTION
We currently log 1-2 errors per iteration failure, depending on the cause of the error, one of them containing no context around the problem. This PR simplifies it to log a single ERROR level message per failed iteration. 