### PR TITLE
Add defaults for HTTP transport settings that make sense for loadtesting

### DIFF
--- a/pkg/f1/f1_root_cmd.go
+++ b/pkg/f1/f1_root_cmd.go
@@ -97,8 +97,6 @@ func ExecuteWithArgs(args []string) error {
 }
 
 func configureHttpDefaults() {
-	runtime.GOMAXPROCS(48)
-
 	// disable TLS verification to reduce performance impact of this load test server
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec  G402 (CWE-295): TLS InsecureSkipVerify set true
 	http.DefaultTransport.(*http.Transport).MaxConnsPerHost = 0


### PR DESCRIPTION
This change sets a number of global HTTP transport defaults in order to allow for higher HTTP throughput when requesting HTTP services at a high number of iterations/s.