### PR TITLE
Remove environment variable map from testing.T

### DIFF
--- a/pkg/f1/options/run_options.go
+++ b/pkg/f1/options/run_options.go
@@ -10,7 +10,6 @@ type RunOptions struct {
 	Scenario            string
 	MaxDuration         time.Duration
 	Concurrency         int
-	Env                 map[string]string
 	Verbose             bool
 	VerboseFail         bool
 	MaxIterations       int32

--- a/pkg/f1/run/run_cmd.go
+++ b/pkg/f1/run/run_cmd.go
@@ -2,8 +2,6 @@ package run
 
 import (
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/form3tech-oss/f1/pkg/f1/options"
@@ -15,7 +13,6 @@ import (
 	"github.com/form3tech-oss/f1/pkg/f1/trigger/api"
 
 	"github.com/form3tech-oss/f1/pkg/f1/testing"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -116,7 +113,6 @@ func runCmdExecute(t api.Builder, hookFunc logging.RegisterLogHookFunc) func(cmd
 			Scenario:            scenarioName,
 			MaxDuration:         duration,
 			Concurrency:         concurrency,
-			Env:                 loadEnvironment(),
 			Verbose:             verbose,
 			VerboseFail:         verboseFail,
 			MaxIterations:       maxIterations,
@@ -135,17 +131,4 @@ func runCmdExecute(t api.Builder, hookFunc logging.RegisterLogHookFunc) func(cmd
 		cmd.SilenceUsage = false
 		return nil
 	}
-}
-
-func loadEnvironment() map[string]string {
-	env := make(map[string]string)
-	for _, e := range os.Environ() {
-		keyAndValue := strings.SplitN(e, "=", 2)
-		if len(keyAndValue) < 2 {
-			log.Warnf("Malformed environment variable was not loaded: %s", e)
-			continue
-		}
-		env[keyAndValue[0]] = keyAndValue[1]
-	}
-	return env
 }

--- a/pkg/f1/run/test_runner.go
+++ b/pkg/f1/run/test_runner.go
@@ -90,7 +90,7 @@ func (r *Run) Do() *RunResult {
 
 	metrics.Instance().Reset()
 	var setupSuccessful bool
-	r.activeScenario, setupSuccessful = testing.NewActiveScenarios(r.Options.Scenario, r.Options.Env, testing.GetScenario(r.Options.Scenario), 0)
+	r.activeScenario, setupSuccessful = testing.NewActiveScenarios(r.Options.Scenario, testing.GetScenario(r.Options.Scenario), 0)
 	r.pushMetrics()
 	fmt.Println(r.result.Setup())
 

--- a/pkg/f1/testing/active_scenario.go
+++ b/pkg/f1/testing/active_scenario.go
@@ -13,7 +13,6 @@ import (
 type ActiveScenario struct {
 	Stages              []Stage
 	TeardownFn          TeardownFn
-	env                 map[string]string
 	Name                string
 	id                  string
 	autoTeardownTimer   *CancellableTimer
@@ -22,12 +21,11 @@ type ActiveScenario struct {
 	m                   *metrics.Metrics
 }
 
-func NewActiveScenarios(name string, env map[string]string, fn MultiStageSetupFn, autoTeardownIdleDuration time.Duration) (*ActiveScenario, bool) {
+func NewActiveScenarios(name string, fn MultiStageSetupFn, autoTeardownIdleDuration time.Duration) (*ActiveScenario, bool) {
 
 	s := &ActiveScenario{
 		Name:              name,
 		id:                uuid.New().String(),
-		env:               env,
 		AutoTeardownAfter: autoTeardownIdleDuration,
 		m:                 metrics.Instance(),
 	}
@@ -68,7 +66,7 @@ func (s *ActiveScenario) SetAutoTeardown(timer *CancellableTimer) {
 
 // Run performs a single iteration of the test. It returns `true` if the test was successful, `false` otherwise.
 func (s *ActiveScenario) Run(metric metrics.MetricType, stage, vu, iter string, f func(t *T)) bool {
-	t := NewT(s.env, vu, iter, s.Name)
+	t := NewT(vu, iter, s.Name)
 	start := time.Now()
 	done := make(chan struct{})
 	go func() {

--- a/pkg/f1/testing/t.go
+++ b/pkg/f1/testing/t.go
@@ -18,19 +18,17 @@ type T struct {
 	// Iteration number, "setup" or "teardown"
 	Iteration string
 	// Logger with user and iteration tags
-	Log         *log.Logger
-	failed      int64
-	Require     *require.Assertions
-	Environment map[string]string
-	Scenario    string
+	Log      *log.Logger
+	failed   int64
+	Require  *require.Assertions
+	Scenario string
 }
 
-func NewT(env map[string]string, vu, iter string, scenarioName string) *T {
+func NewT(vu, iter string, scenarioName string) *T {
 	t := &T{
 		VirtualUser: vu,
 		Iteration:   iter,
 		Log:         log.WithField("u", vu).WithField("i", iter).WithField("scenario", scenarioName).Logger,
-		Environment: env,
 		Scenario:    scenarioName,
 	}
 	t.Require = require.New(t)


### PR DESCRIPTION
Simplify `testing.T` by removing environment variable map from it because it's not used much. Scenarios may use `os.Getenv()` to fetch environment variables where necessary.