### PR TITLE
Add methods Logger() and Require() on testing.T

### DIFF
--- a/internal/run/run_stage_test.go
+++ b/internal/run/run_stage_test.go
@@ -273,7 +273,7 @@ func (s *RunTestStage) a_test_scenario_that_fails_intermittently() *RunTestStage
 				atomic.AddInt32(s.iterationTeardownCount, 1)
 			})
 			count := atomic.AddInt32(&s.runCount, 1)
-			t.Require.True(count%2 == 0)
+			t.Require().True(count%2 == 0)
 		}
 	})
 	return s

--- a/pkg/f1/testing/t.go
+++ b/pkg/f1/testing/t.go
@@ -20,10 +20,10 @@ import (
 type T struct {
 	// "iteration " + iteration number or "setup"
 	Iteration string
-	// Logger with user and iteration tags
-	Logger        *log.Logger
+	// logger with user and iteration tags
+	logger        *log.Logger
 	failed        int64
-	Require       *require.Assertions
+	require       *require.Assertions
 	Scenario      string
 	teardownStack []func()
 }
@@ -31,12 +31,20 @@ type T struct {
 func NewT(iter, scenarioName string) (*T, func()) {
 	t := &T{
 		Iteration:     iter,
-		Logger:        log.WithField("i", iter).WithField("scenario", scenarioName).Logger,
+		logger:        log.WithField("i", iter).WithField("scenario", scenarioName).Logger,
 		Scenario:      scenarioName,
 		teardownStack: []func(){},
 	}
-	t.Require = require.New(t)
+	t.require = require.New(t)
 	return t, t.teardown
+}
+
+func (t *T) Logger() *log.Logger {
+	return t.logger
+}
+
+func (t *T) Require() *require.Assertions {
+	return t.require
 }
 
 // Name returns the name of the running Scenario.
@@ -84,13 +92,13 @@ func (t *T) Fatal(err error) {
 // Log formats its arguments using default formatting, analogous to Println, and records the text in the error log.
 // The text will be printed only if f1 is running in verbose mode.
 func (t *T) Log(args ...interface{}) {
-	t.Logger.Error(args...)
+	t.logger.Error(args...)
 }
 
 // Logf formats its arguments according to the format, analogous to Printf, and records the text in the error log.
 // A final newline is added if not provided. The text will be printed only if f1 is running in verbose mode.
 func (t *T) Logf(format string, args ...interface{}) {
-	t.Logger.Errorf(format, args...)
+	t.logger.Errorf(format, args...)
 }
 
 // Failed reports whether the function has failed.


### PR DESCRIPTION
This PR add methods `Logger()` and `Require()` to `testing.T` in order to allow others to define a meaningful interface on top of `testing.T` (for example `f1-tests`). With this change, `f1-tests` doesn't need to depend on `f1` anymore by defining an appropriate interface.