### PR TITLE
Ensure that scenario setup teardown is called

### DIFF
--- a/internal/run/active_scenario.go
+++ b/internal/run/active_scenario.go
@@ -19,7 +19,7 @@ type ActiveScenario struct {
 	Teardown func()
 }
 
-func NewActiveScenario(scenario *scenarios.Scenario) (*ActiveScenario, bool) {
+func NewActiveScenario(scenario *scenarios.Scenario) *ActiveScenario {
 	t, teardown := testing.NewT("setup", scenario.Name)
 
 	s := &ActiveScenario{
@@ -40,7 +40,7 @@ func NewActiveScenario(scenario *scenarios.Scenario) (*ActiveScenario, bool) {
 	// wait for completion
 	<-done
 	s.m.Record(metrics.SetupResult, scenario.Name, "setup", metrics.Result(t.Failed()), time.Since(start).Nanoseconds())
-	return s, !t.Failed()
+	return s
 }
 
 // Run performs a single iteration of the test. It returns `true` if the test was successful, `false` otherwise.

--- a/internal/run/result.go
+++ b/internal/run/result.go
@@ -107,7 +107,7 @@ func (r *RunResult) Error() error {
 		errorStrings[i] = fmt.Sprintf("Error %d: %s", i, r.errors[i].Error())
 	}
 
-	return fmt.Errorf(strings.Join(errorStrings, " ;"))
+	return fmt.Errorf(strings.Join(errorStrings, "; "))
 }
 
 func parseQuantiles(quantiles []*io_prometheus_client.Quantile) DurationPercentileMap {

--- a/internal/run/result.go
+++ b/internal/run/result.go
@@ -144,7 +144,7 @@ var (
 `))
 	setup = template.Must(template.New("setup").
 		Funcs(templateFunctions).
-		Parse(`{cyan}[Setup]{-}  {{if .Error}}{red}✘ {{.Error}}{-}{{else}}{green}✔{-}{{end}}`))
+		Parse(`{cyan}[Setup]{-}    {{if .Error}}{red}✘ {{.Error}}{-}{{else}}{green}✔{-}{{end}}`))
 
 	progress = template.Must(template.New("result parse").
 			Funcs(templateFunctions).
@@ -152,7 +152,7 @@ var (
 {{- with .SuccessfulIterationDurations}}   p(50): {{.Get 0.5}},  p(95): {{.Get 0.95}}, p(100): {{.Get 1.0}}{{end}}`))
 	teardown = template.Must(template.New("teardown").
 			Funcs(templateFunctions).
-			Parse(`{cyan}[Teardown]{-}  {{if .Error}}{red}✘ {{.Error}}{-}{{else}}{green}✔{-}{{end}}`))
+			Parse(`{cyan}[Teardown]{-} {{if .Error}}{red}✘ {{.Error}}{-}{{else}}{green}✔{-}{{end}}`))
 	timeout = template.Must(template.New("timeout").
 		Funcs(templateFunctions).
 		Parse(`{cyan}[{{durationSeconds .Duration | printf "%5s"}}]  Max Duration Elapsed - waiting for active tests to complete{-}`))

--- a/internal/run/run_cmd_test.go
+++ b/internal/run/run_cmd_test.go
@@ -536,7 +536,6 @@ func TestRunScenarioThatFailsOccasionally(t *testing.T) {
 }
 
 func TestInterruptedRun(t *testing.T) {
-
 	given, when, then := NewRunTestStage(t)
 	given.
 		a_rate_of("5/10ms").and().
@@ -544,13 +543,13 @@ func TestInterruptedRun(t *testing.T) {
 		a_scenario_where_each_iteration_takes(0 * time.Second).and().
 		a_distribution_type("none")
 
-	when.the_test_run_is_started().and().
+	when.
+		the_test_run_is_started().and().
 		the_test_run_is_interrupted()
 
 	then.
 		setup_teardown_is_called_within_50ms().and().
 		metrics_are_pushed_to_prometheus()
-
 }
 
 func TestFinalRunMetrics(t *testing.T) {

--- a/internal/run/test_runner.go
+++ b/internal/run/test_runner.go
@@ -94,6 +94,7 @@ func (r *Run) Do(s *scenarios.Scenarios) *RunResult {
 	metrics.Instance().Reset()
 	var setupSuccessful bool
 	r.activeScenario, setupSuccessful = NewActiveScenario(s.GetScenario(r.Options.Scenario))
+	defer r.activeScenario.Teardown()
 	r.pushMetrics()
 	fmt.Println(r.result.Setup())
 
@@ -115,7 +116,6 @@ func (r *Run) Do(s *scenarios.Scenarios) *RunResult {
 	metricsTick.Close()
 	r.gatherMetrics()
 
-	r.activeScenario.Teardown()
 	r.pushMetrics()
 	fmt.Println(r.result.Teardown())
 

--- a/internal/run/test_runner.go
+++ b/internal/run/test_runner.go
@@ -94,6 +94,7 @@ func (r *Run) Do(s *scenarios.Scenarios) *RunResult {
 	metrics.Instance().Reset()
 
 	r.activeScenario = NewActiveScenario(s.GetScenario(r.Options.Scenario))
+	r.pushMetrics()
 	defer r.teardownActiveScenario()
 
 	if r.activeScenario.t.Failed() {

--- a/internal/run/test_runner.go
+++ b/internal/run/test_runner.go
@@ -129,7 +129,7 @@ func (r *Run) teardownActiveScenario() {
 		r.fail("teardown failed")
 	}
 	r.pushMetrics()
-	fmt.Println(r.result.Setup())
+	fmt.Println(r.result.Teardown())
 }
 
 func (r *Run) configureLogging() {

--- a/pkg/f1/testing/t.go
+++ b/pkg/f1/testing/t.go
@@ -140,6 +140,7 @@ func CheckResults(t *T, done chan<- struct{}) {
 		err, isError := r.(error)
 		if isError {
 			stack := string(debug.Stack())
+			t.Fail()
 			t.logger.
 				WithField("stack_trace", stack).
 				WithError(err).


### PR DESCRIPTION
The teardown function for the scenario setup phase was previously called manually, but when a scenario setup failed, it wasn't called at all. We now defer its execution so it will always be called properly.

This also fixes an issue with the test reporter that reported the setup phase as passing with a green checkmark when in fact it failed.

More improvements should be made to error reporting to make it clear during which phase of which stage (e.g. run of setup, teardown of setup, run of iteration, teardown of iteration) an error happened now that we have a `t.Cleanup()` style teardown handling. This would go in another PR though.