### PR TITLE
Report run duration for runs without any iterations as 0 seconds

### DIFF
--- a/internal/run/result.go
+++ b/internal/run/result.go
@@ -183,6 +183,10 @@ func (r *RunResult) Progress() string {
 }
 
 func (r *RunResult) Duration() time.Duration {
+	if r.StartTime().IsZero() {
+		return 0
+	}
+
 	return time.Since(r.StartTime())
 }
 


### PR DESCRIPTION
This PR fixes the test duration printed at the end of a scenario in cases where the setup failed.

Before this PR:

```
Load Test Failed
Error: setup failed
0 iterations started in 292 years 24 weeks 3 days 23 hours 47 minutes 16 seconds 854 milliseconds 775 microseconds (0/second)
```

With this PR:

```
Load Test Failed
Error: setup failed
0 iterations started in 0 seconds (0/second)
```