### PR TITLE
Remove default case to reduce cpu consumption

### DIFF
--- a/internal/trigger/file/stages_worker.go
+++ b/internal/trigger/file/stages_worker.go
@@ -60,7 +60,6 @@ func newStagesWorker(stages []runnableStage) api.WorkTriggerer {
 					unsetEnvs(stage.params)
 					time.Sleep(safeThresholdBeforeNextIteration)
 					isListening = false
-				default:
 				}
 			}
 		}


### PR DESCRIPTION
When running a stage configured loadtest, the agent always take 100% of a core, as there is a spin in a select in the file internal/trigger/file/stages_worker.go .

With this MR, it only tick when there is something to do.


This PR is a copy of the [original](https://github.com/form3tech-oss/f1/pull/131), but will run the CI in this repo.