### PR TITLE
Fix rounding on iteration-distribution calculations

### DIFF
--- a/internal/trigger/api/iteration_distribution.go
+++ b/internal/trigger/api/iteration_distribution.go
@@ -55,7 +55,7 @@ func withRegularDistribution(iterationDuration time.Duration, rateFn RateFunctio
 		}
 
 		accRate += float64(rate) / float64(tickSteps)
-		accRate = math.Round(accRate*10_000_000) / 10_000_000
+		accRate = math.Ceil(accRate*10_000_000) / 10_000_000
 		remainingSteps--
 
 		if accRate < 1 {

--- a/internal/trigger/api/iteration_distribution_test.go
+++ b/internal/trigger/api/iteration_distribution_test.go
@@ -126,6 +126,16 @@ func TestRegularRateDistribution(t *testing.T) {
 			rate:                     900,
 			expectedDistributedRates: repeatSlice([]int{0, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 100),
 		},
+		{
+			iterationDuration:        2 * time.Minute,
+			rate:                     1,
+			expectedDistributedRates: append(repeatValue(0, 1199), 1),
+		},
+		{
+			iterationDuration:        4 * time.Minute,
+			rate:                     2,
+			expectedDistributedRates: repeatSlice(append(repeatValue(0, 1199), 1), 2),
+		},
 	} {
 		t.Run(fmt.Sprintf("%d: iteration duration %s, rate %d", i, test.iterationDuration, test.rate), func(t *testing.T) {
 			t.Parallel()

--- a/internal/trigger/api/iteration_distribution_test.go
+++ b/internal/trigger/api/iteration_distribution_test.go
@@ -32,6 +32,22 @@ func TestRegularRateDistribution(t *testing.T) {
 			expectedDistributedRates: []int{5, 5},
 		},
 		{
+			iterationDuration:        215 * time.Millisecond,
+			rate:                     1,
+			expectedDistributedRates: []int{0, 1},
+		},
+		{
+			iterationDuration:        299 * time.Millisecond,
+			rate:                     1,
+			expectedDistributedRates: []int{0, 1},
+		},
+
+		{
+			iterationDuration:        300 * time.Millisecond,
+			rate:                     1,
+			expectedDistributedRates: []int{0, 0, 1},
+		},
+		{
 			iterationDuration:        900 * time.Millisecond,
 			rate:                     7,
 			expectedDistributedRates: []int{0, 1, 1, 1, 0, 1, 1, 1, 1},


### PR DESCRIPTION
# Description
Co-authored-by: Kevin Intriago <kevin.intriago@form3.tech>

When using  very low rates intended to only fire the scenario a couple times over the duration, the calculations for the iteration distribution could fail to add up to 1 by the last tick of the iteration, missing executions (or failing to trigger the scenario at all if only 1 run was intended).

Using `Ceil` instead of `Round` ensures 1 is always reached consistently. See added test cases for examples that would fail to trigger the scenario without the fix.