### PR TITLE
feat: optional id label for all metrics

### DIFF
--- a/internal/run/main_test.go
+++ b/internal/run/main_test.go
@@ -13,6 +13,7 @@ import (
 var fakePrometheus FakePrometheus
 
 const fakePrometheusNamespace = "test-namespace"
+const fakePrometheusID = "test-run-name"
 
 func TestMain(m *testing.M) {
 
@@ -26,6 +27,10 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 	err = os.Setenv("PROMETHEUS_NAMESPACE", fakePrometheusNamespace)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = os.Setenv("PROMETHEUS_ID_LABEL", fakePrometheusID)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/run/main_test.go
+++ b/internal/run/main_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = os.Setenv("PROMETHEUS_ID_LABEL", fakePrometheusID)
+	err = os.Setenv("PROMETHEUS_LABEL_ID", fakePrometheusID)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/run/run_cmd_test.go
+++ b/internal/run/run_cmd_test.go
@@ -585,7 +585,7 @@ func TestSetupMetricsAreRecorded(t *testing.T) {
 		there_is_a_metric_called("form3_loadtest_setup")
 }
 
-func TestNamespaceLabel(t *testing.T) {
+func TestGroupedLabels(t *testing.T) {
 	given, when, then := NewRunTestStage(t)
 
 	given.
@@ -596,7 +596,8 @@ func TestNamespaceLabel(t *testing.T) {
 
 	then.
 		metrics_are_pushed_to_prometheus().and().
-		all_exported_metrics_contain_label("namespace", fakePrometheusNamespace)
+		all_exported_metrics_contain_label("namespace", fakePrometheusNamespace).and().
+		all_exported_metrics_contain_label("id", fakePrometheusID)
 }
 
 func TestFailureCounts(t *testing.T) {

--- a/internal/run/test_runner.go
+++ b/internal/run/test_runner.go
@@ -44,9 +44,14 @@ func NewRun(options options.RunOptions, t *api.Trigger) (*Run, error) {
 	if prometheusUrl != "" {
 		run.pusher = push.New(prometheusUrl, "f1-"+options.Scenario).Gatherer(prometheus.DefaultGatherer)
 
-		prometheusNamespace := os.Getenv("PROMETHEUS_NAMESPACE")
-		if prometheusNamespace != "" {
-			run.pusher = run.pusher.Grouping("namespace", prometheusNamespace)
+		namespaceLabel := os.Getenv("PROMETHEUS_NAMESPACE")
+		if namespaceLabel != "" {
+			run.pusher = run.pusher.Grouping("namespace", namespaceLabel)
+		}
+
+		idLabel := os.Getenv("PROMETHEUS_ID_LABEL")
+		if idLabel != "" {
+			run.pusher = run.pusher.Grouping("id", idLabel)
 		}
 	}
 	if run.Options.RegisterLogHookFunc == nil {

--- a/internal/run/test_runner.go
+++ b/internal/run/test_runner.go
@@ -49,7 +49,7 @@ func NewRun(options options.RunOptions, t *api.Trigger) (*Run, error) {
 			run.pusher = run.pusher.Grouping("namespace", namespaceLabel)
 		}
 
-		idLabel := os.Getenv("PROMETHEUS_ID_LABEL")
+		idLabel := os.Getenv("PROMETHEUS_LABEL_ID")
 		if idLabel != "" {
 			run.pusher = run.pusher.Grouping("id", idLabel)
 		}


### PR DESCRIPTION
Metrics are exported via prometheus push gateway. Unfortunately, push gateway is only a super simple cache. It does not add any common labels, such as server, or pod name, and when metric with the same label set is provided, it overrides the latest value with a new one. That's why it's crucial to make label values unique.

With the new `id` label it should be a little easier. It's optional and needed only when metric entries might be not unique.