### PR TITLE
chore: update actions & add breaking change guard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.head_ref }}
           fetch-depth: 0
       - name: version
         id: version


### PR DESCRIPTION
Motivation:

Make sure no breaking changes are introduced without marking them as such. This is just to help contributors. Automatic release is not part of this change.

Changes:
 - Updates `checkout` and `setup-go` actions and locks them to a sha version
 - Add [git-version](https://github.com/marketplace/actions/git-version) to generate semantic versions. Github verified creator at time of addition. 
 - Add semantic version release check for breaking API changes: 
<img width="1903" alt="Screenshot 2024-03-07 at 08 22 49" src="https://github.com/form3tech-oss/f1/assets/82881913/04e8e959-41c0-4646-a347-075c1bfe86f6">

 