### PR TITLE
feat: extract env settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,17 @@ It provides the following information:
 - `(20/s)` (attempted) rate,
 - `p(50): 16.899154ms p(95): 19.1134ms p(100): 21.435088ms` average time per iteration, for a given percentile.
 
+### Environment variables
 
+| Name | Format | Default | Description |
+| --- | --- | --- | --- |
+| `PROMETHEUS_PUSH_GATEWAY` | string - `host:port` or `ip:port` | `""` | Configures the address of a [Prometheus Push Gateway](https://prometheus.io/docs/instrumenting/pushing/) for exposing metrics. The prometheus job name configured will be `f1-{scenario_name}`. Disabled by default.|
+| `PROMETHEUS_NAMESPACE` | string | `""` | Sets the metric label `namespace` to the specified value. Label is omitted if the value provided is empty.|
+| `PROMETHEUS_LABEL_ID` | string | `""` | Sets the metric label `id` to the specified value. Label is omitted if the value provided is empty.|
+| `LOG_FILE_PATH` | string | `""`| Specify the log file path if `--verbose` is enabled. The logfile path will be an automatically generated temp file if not specified. |
+| `TRACE` | bool | "" | If set to `"true"` detailed internal tracing is printed to stdout. Disabled by default. |
+| `FLUENTD_HOST`| string | "" | Enable log shipping to a fluentd host. Must together with `FLUENTD_PORT`. Disabled by default. |
+| `FLUENTD_PORT`| int | "" | Enable log shipping to a fluentd host. Must together with `FLUENTD_HOST`. Disabled by default. |
 
 ## Design decisions
 ### Why did we decide to write our own load testing tool?

--- a/internal/chart/chart_cmd.go
+++ b/internal/chart/chart_cmd.go
@@ -10,10 +10,11 @@ import (
 	"github.com/wcharczuk/go-chart/v2"
 
 	"github.com/form3tech-oss/f1/v2/internal/support/errorh"
+	"github.com/form3tech-oss/f1/v2/internal/trace"
 	"github.com/form3tech-oss/f1/v2/internal/trigger/api"
 )
 
-func Cmd(builders []api.Builder) *cobra.Command {
+func Cmd(builders []api.Builder, tracer trace.Tracer) *cobra.Command {
 	chartCmd := &cobra.Command{
 		Use:   "chart <subcommand>",
 		Short: "plots a chart of the test scenarios that would be triggered over time with the provided run function",
@@ -23,7 +24,7 @@ func Cmd(builders []api.Builder) *cobra.Command {
 		triggerCmd := &cobra.Command{
 			Use:   t.Name,
 			Short: t.Description,
-			RunE:  chartCmdExecute(t),
+			RunE:  chartCmdExecute(t, tracer),
 		}
 		triggerCmd.Flags().String("chart-start", time.Now().Format(time.RFC3339), "Optional start time for the chart")
 		triggerCmd.Flags().Duration("chart-duration", 10*time.Minute, "Duration for the chart")
@@ -35,7 +36,7 @@ func Cmd(builders []api.Builder) *cobra.Command {
 	return chartCmd
 }
 
-func chartCmdExecute(t api.Builder) func(cmd *cobra.Command, args []string) error {
+func chartCmdExecute(t api.Builder, tracer trace.Tracer) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
 
@@ -56,7 +57,7 @@ func chartCmdExecute(t api.Builder) func(cmd *cobra.Command, args []string) erro
 			return fmt.Errorf("getting flag: %w", err)
 		}
 
-		trig, err := t.New(cmd.Flags())
+		trig, err := t.New(cmd.Flags(), tracer)
 		if err != nil {
 			return fmt.Errorf("creating builder: %w", err)
 		}

--- a/internal/chart/chart_cmd_stage_test.go
+++ b/internal/chart/chart_cmd_stage_test.go
@@ -1,12 +1,14 @@
 package chart
 
 import (
+	"io"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/form3tech-oss/f1/v2/internal/trace"
 	"github.com/form3tech-oss/f1/v2/internal/trigger"
 )
 
@@ -31,7 +33,7 @@ func (s *ChartTestStage) and() *ChartTestStage {
 }
 
 func (s *ChartTestStage) i_execute_the_chart_command() *ChartTestStage {
-	cmd := Cmd(trigger.GetBuilders())
+	cmd := Cmd(trigger.GetBuilders(), trace.NewConsoleTracer(io.Discard))
 	cmd.SetArgs(s.args)
 	s.err = cmd.Execute()
 	return s

--- a/internal/envsettings/env.go
+++ b/internal/envsettings/env.go
@@ -1,0 +1,55 @@
+package envsettings
+
+import (
+	"os"
+)
+
+const (
+	EnvPrometheusLabelID     = "PROMETHEUS_LABEL_ID"
+	EnvPrometheusNamespace   = "PROMETHEUS_NAMESPACE"
+	EnvPrometheusPushGateway = "PROMETHEUS_PUSH_GATEWAY"
+
+	EnvLogFilePath = "LOG_FILE_PATH"
+
+	EnvTrace             = "TRACE"
+	EnvTraceEnabledValue = "true"
+
+	EnvFluentdHost = "FLUENTD_HOST"
+	EnvFluentdPort = "FLUENTD_PORT"
+)
+
+type Prometheus struct {
+	LabelID     string
+	Namespace   string
+	PushGateway string
+}
+
+type Fluentd struct {
+	Host string
+	Port string
+}
+
+type Settings struct {
+	LogFilePath string
+
+	Trace bool
+
+	Fluentd    Fluentd
+	Prometheus Prometheus
+}
+
+func Get() Settings {
+	return Settings{
+		LogFilePath: os.Getenv(EnvLogFilePath),
+		Trace:       os.Getenv(EnvTrace) == EnvTraceEnabledValue,
+		Fluentd: Fluentd{
+			Host: os.Getenv(EnvFluentdHost),
+			Port: os.Getenv(EnvFluentdPort),
+		},
+		Prometheus: Prometheus{
+			LabelID:     os.Getenv(EnvPrometheusLabelID),
+			Namespace:   os.Getenv(EnvPrometheusNamespace),
+			PushGateway: os.Getenv(EnvPrometheusPushGateway),
+		},
+	}
+}

--- a/internal/fluentd/hook.go
+++ b/internal/fluentd/hook.go
@@ -1,36 +1,40 @@
 package fluentd
 
 import (
-	"os"
+	"fmt"
 	"strconv"
 
 	"github.com/evalphobia/logrus_fluent"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/form3tech-oss/f1/v2/internal/logging"
 )
 
-func AddFluentdLoggingHook(scenario string) {
-	host := os.Getenv("FLUENTD_HOST")
-	port := os.Getenv("FLUENTD_PORT")
-	if host == "" || port == "" {
-		return
-	}
-	portNum, err := strconv.Atoi(port)
-	if err != nil {
-		log.WithError(err).Error("unable to parse fluentd port")
-		return
-	}
-	hook, err := logrus_fluent.NewWithConfig(logrus_fluent.Config{
-		Port:                portNum,
-		Host:                host,
-		DefaultTag:          "f1-" + scenario,
-		TagPrefix:           "service",
-		DefaultMessageField: "message",
-		AsyncConnect:        false,
-		MarshalAsJSON:       true,
-	})
-	if err != nil {
-		panic(err)
-	}
+func LoggingHook(host, port string) logging.RegisterLogHookFunc {
+	return func(scenario string) error {
+		if host == "" || port == "" {
+			return nil
+		}
 
-	log.AddHook(hook)
+		portNum, err := strconv.Atoi(port)
+		if err != nil {
+			return fmt.Errorf("parsing fluentd port: %w", err)
+		}
+
+		hook, err := logrus_fluent.NewWithConfig(logrus_fluent.Config{
+			Port:                portNum,
+			Host:                host,
+			DefaultTag:          "f1-" + scenario,
+			TagPrefix:           "service",
+			DefaultMessageField: "message",
+			AsyncConnect:        false,
+			MarshalAsJSON:       true,
+		})
+		if err != nil {
+			return fmt.Errorf("creating fluent config: %w", err)
+		}
+
+		log.AddHook(hook)
+		return nil
+	}
 }

--- a/internal/logging/types.go
+++ b/internal/logging/types.go
@@ -1,5 +1,7 @@
 package logging
 
-type RegisterLogHookFunc func(scenario string)
+type RegisterLogHookFunc func(scenario string) error
 
-var NoneRegisterLogHookFunc = func(string) {}
+func NoneRegisterLogHookFunc(string) error {
+	return nil
+}

--- a/internal/run/logging.go
+++ b/internal/run/logging.go
@@ -25,16 +25,15 @@ func getGeneratedLogFilePath(scenario string) string {
 	)
 }
 
-func getLogFilePath(scenario string) string {
-	logFilePath := os.Getenv("LOG_FILE_PATH")
-	if logFilePath != "" && directoryExists(logFilePath) {
-		return logFilePath
+func getLogFilePath(scenario string, logPath string) string {
+	if logPath != "" && directoryExists(logPath) {
+		return logPath
 	}
 	return getGeneratedLogFilePath(scenario)
 }
 
-func redirectLoggingToFile(scenario string) string {
-	logFilePath := getLogFilePath(scenario)
+func redirectLoggingToFile(scenario string, logPath string) string {
+	logFilePath := getLogFilePath(scenario, logPath)
 
 	file, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err == nil {

--- a/internal/run/logging_test.go
+++ b/internal/run/logging_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 func TestProvidingCustomLogFilePathWithDirectoryThatDoesExist(t *testing.T) {
-	t.Setenv("LOG_FILE_PATH", "/does-not-exist/my-scenario.log")
+	logPath := "/does-not-exist/my-scenario.log"
 	expected := getGeneratedLogFilePath("my-scenario")
 
-	actual := getLogFilePath("my-scenario")
+	actual := getLogFilePath("my-scenario", logPath)
 
 	assert.NotEqual(t, "", actual)
 	assert.Equal(t, expected, actual)
@@ -20,19 +20,17 @@ func TestProvidingCustomLogFilePathWithDirectoryThatDoesExist(t *testing.T) {
 
 func TestProvidingCustomLogFilePathWithDirectoryThatDoesNotExistResultsInGeneratedLogFile(t *testing.T) {
 	expected := filepath.Join(os.TempDir(), "my-scenario.log")
-	t.Setenv("LOG_FILE_PATH", expected)
 
-	actual := getLogFilePath("my-scenario")
+	actual := getLogFilePath("my-scenario", expected)
 
 	assert.NotEqual(t, "", actual)
 	assert.Equal(t, expected, actual)
 }
 
 func TestProvidingCustomLogFilePathWhichIsEmptyResultsInGeneratedLogFile(t *testing.T) {
-	t.Setenv("LOG_FILE_PATH", "")
 	expected := getGeneratedLogFilePath("my-scenario")
 
-	actual := getLogFilePath("my-scenario")
+	actual := getLogFilePath("my-scenario", "")
 
 	assert.NotEqual(t, "", actual)
 	assert.Equal(t, expected, actual)

--- a/internal/run/main_test.go
+++ b/internal/run/main_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/phayes/freeport"
 	log "github.com/sirupsen/logrus"
 	"go.uber.org/goleak"
+
+	"github.com/form3tech-oss/f1/v2/internal/envsettings"
 )
 
 var fakePrometheus FakePrometheus
@@ -23,15 +25,15 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = os.Setenv("PROMETHEUS_PUSH_GATEWAY", fmt.Sprintf("http://localhost:%d/", fakePrometheus.Port))
+	err = os.Setenv(envsettings.EnvPrometheusPushGateway, fmt.Sprintf("http://localhost:%d/", fakePrometheus.Port))
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = os.Setenv("PROMETHEUS_NAMESPACE", fakePrometheusNamespace)
+	err = os.Setenv(envsettings.EnvPrometheusNamespace, fakePrometheusNamespace)
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = os.Setenv("PROMETHEUS_LABEL_ID", fakePrometheusID)
+	err = os.Setenv(envsettings.EnvPrometheusLabelID, fakePrometheusID)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/run/run_cmd_test.go
+++ b/internal/run/run_cmd_test.go
@@ -686,3 +686,27 @@ func TestParameterisedMaxFailures(t *testing.T) {
 		})
 	}
 }
+
+func TestTracing(t *testing.T) {
+	given, when, then := NewRunTestStage(t)
+
+	given.
+		tracing_is_enabled().and().
+		a_concurrent_constant_trigger_is_configured().and()
+
+	when.i_execute_the_run_command()
+
+	then.the_trace_output_should_be_present()
+}
+
+func TestFluentd_InvalidPort(t *testing.T) {
+	given, when, then := NewRunTestStage(t)
+
+	given.
+		a_fluentd_config_with_host_and_port("host", "port").and().
+		a_concurrent_constant_trigger_is_configured()
+
+	when.i_execute_the_run_command()
+
+	then.run_fails_with_error_containing("parsing fluentd port")
+}

--- a/internal/trace/console_tracer.go
+++ b/internal/trace/console_tracer.go
@@ -1,0 +1,76 @@
+package trace
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	termReset  = "\033[0m"
+	termGray   = "\033[37m"
+	termYellow = "\033[33m"
+	termBlue   = "\033[34m"
+	termRed    = "\033[31m"
+)
+
+type ConsoleTracer struct {
+	writer io.Writer
+}
+
+func NewConsoleTracer(output io.Writer) *ConsoleTracer {
+	return &ConsoleTracer{writer: output}
+}
+
+var _ Tracer = &ConsoleTracer{}
+
+func colorString(s string, c string) string {
+	return c + s + termReset
+}
+
+func (t *ConsoleTracer) ReceivedFromChannel(name string) {
+	t.event("Received from Channel '%s'", name)
+}
+
+func (t *ConsoleTracer) SentToChannel(name string) {
+	t.event("Sent to Channel '%s'", name)
+}
+
+func (t *ConsoleTracer) SendingToChannel(name string) {
+	t.event("Sending to Channel '%s'", name)
+}
+
+func (t *ConsoleTracer) Event(message string, args ...any) {
+	t.event(message, args...)
+}
+
+func (t *ConsoleTracer) event(message string, args ...any) {
+	pc := make([]uintptr, 15)
+	n := runtime.Callers(3, pc)
+	frames := runtime.CallersFrames(pc[:n])
+	frame, _ := frames.Next()
+
+	keywords := []string{"channel", "Channel"}
+
+	fMessage := colorString(fmt.Sprintf(message, args...), termYellow)
+
+	for _, s := range keywords {
+		fMessage = strings.Replace(fMessage, s, termRed+s+termYellow, 1)
+	}
+
+	fileName := frame.File + strconv.Itoa(frame.Line)
+	fileName = colorString(fileName, termBlue)
+
+	now := time.Now()
+	formattedTime := fmt.Sprintf("%02d:%02d:%02d %02dms",
+		now.Hour(), now.Minute(), now.Second(), now.Nanosecond()/int(time.Millisecond))
+
+	timePart := colorString(fmt.Sprintf("[TRACE - %s]: ", formattedTime), termGray)
+	messagePart := colorString(fMessage+" -> ", termGray)
+	filePart := colorString(fileName, termBlue)
+
+	fmt.Fprintln(t.writer, timePart+messagePart+filePart)
+}

--- a/internal/trace/nil_tracer.go
+++ b/internal/trace/nil_tracer.go
@@ -1,0 +1,21 @@
+package trace
+
+var _ Tracer = &NilTracer{}
+
+func NewNilTracer() *NilTracer {
+	return &NilTracer{}
+}
+
+type NilTracer struct{}
+
+func (*NilTracer) ReceivedFromChannel(string) {
+}
+
+func (*NilTracer) SentToChannel(string) {
+}
+
+func (*NilTracer) SendingToChannel(string) {
+}
+
+func (*NilTracer) Event(string, ...any) {
+}

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -1,70 +1,8 @@
 package trace
 
-import (
-	"fmt"
-	"os"
-	"runtime"
-	"strings"
-	"time"
-)
-
-var (
-	reset  = "\033[0m"
-	gray   = "\033[37m"
-	yellow = "\033[33m"
-	blue   = "\033[34m"
-	red    = "\033[31m"
-)
-
-func colorString(s string, c string) string {
-	return c + s + reset
-}
-
-func ReceivedFromChannel(name string) {
-	event("Received from Channel '%s'", name)
-}
-
-func SentToChannel(name string) {
-	event("Sent to Channel '%s'", name)
-}
-
-func SendingToChannel(name string) {
-	event("Sending to Channel '%s'", name)
-}
-
-func Event(message string, args ...interface{}) {
-	event(message, args...)
-}
-
-func event(message string, args ...interface{}) {
-	if os.Getenv("TRACE") != "true" {
-		return
-	}
-
-	pc := make([]uintptr, 15)
-	n := runtime.Callers(3, pc)
-	frames := runtime.CallersFrames(pc[:n])
-	frame, _ := frames.Next()
-
-	keywords := []string{"channel", "Channel"}
-
-	fMessage := colorString(fmt.Sprintf(message, args...), yellow)
-
-	for _, s := range keywords {
-		fMessage = strings.Replace(fMessage, s, red+s+yellow, 1)
-	}
-
-	fileName := strings.Replace(frame.File, os.Getenv("GOPATH")+"/src/github.com/form3tech/k6-tests", ".", 1)
-	fileName = fmt.Sprintf("%s:%d", fileName, frame.Line)
-	fileName = colorString(fileName, blue)
-
-	t := time.Now()
-	formattedTime := fmt.Sprintf("%02d:%02d:%02d %02dms",
-		t.Hour(), t.Minute(), t.Second(), t.Nanosecond()/int(time.Millisecond))
-
-	timePart := colorString(fmt.Sprintf("[TRACE - %s]: ", formattedTime), gray)
-	messagePart := colorString(fMessage+" -> ", gray)
-	filePart := colorString(fileName, blue)
-
-	fmt.Println(timePart + messagePart + filePart)
+type Tracer interface {
+	ReceivedFromChannel(name string)
+	SendingToChannel(name string)
+	SentToChannel(name string)
+	Event(message string, args ...any)
 }

--- a/internal/trigger/api/api.go
+++ b/internal/trigger/api/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/form3tech-oss/f1/v2/internal/options"
+	"github.com/form3tech-oss/f1/v2/internal/trace"
 )
 
 type (
@@ -28,7 +29,7 @@ type Builder struct {
 	IgnoreCommonFlags bool
 }
 
-type Constructor func(*pflag.FlagSet) (*Trigger, error)
+type Constructor func(*pflag.FlagSet, trace.Tracer) (*Trigger, error)
 
 type Trigger struct {
 	Trigger     WorkTriggerer

--- a/internal/trigger/constant/constant_rate.go
+++ b/internal/trigger/constant/constant_rate.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"github.com/form3tech-oss/f1/v2/internal/trace"
 	"github.com/form3tech-oss/f1/v2/internal/trigger/api"
 	"github.com/form3tech-oss/f1/v2/internal/trigger/rate"
 )
@@ -20,7 +21,7 @@ func Rate() api.Builder {
 		Name:        "constant <scenario>",
 		Description: "triggers test iterations at a constant rate",
 		Flags:       flags,
-		New: func(params *pflag.FlagSet) (*api.Trigger, error) {
+		New: func(params *pflag.FlagSet, tracer trace.Tracer) (*api.Trigger, error) {
 			rateArg, err := params.GetString("rate")
 			if err != nil {
 				return nil, fmt.Errorf("getting flag: %w", err)
@@ -40,7 +41,7 @@ func Rate() api.Builder {
 			}
 
 			return &api.Trigger{
-					Trigger:     api.NewIterationWorker(rates.IterationDuration, rates.Rate),
+					Trigger:     api.NewIterationWorker(rates.IterationDuration, rates.Rate, tracer),
 					Description: fmt.Sprintf("%s constant rate, using distribution %s", rateArg, distributionTypeArg),
 					DryRun:      rates.Rate,
 				},

--- a/internal/trigger/file/file_rate.go
+++ b/internal/trigger/file/file_rate.go
@@ -10,6 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
+	"github.com/form3tech-oss/f1/v2/internal/trace"
 	"github.com/form3tech-oss/f1/v2/internal/trigger/api"
 )
 
@@ -40,7 +41,7 @@ func Rate() api.Builder {
 		Name:        "file <filename>",
 		Description: "triggers test iterations from a yaml config file",
 		Flags:       flags,
-		New: func(flags *pflag.FlagSet) (*api.Trigger, error) {
+		New: func(flags *pflag.FlagSet, tracer trace.Tracer) (*api.Trigger, error) {
 			filename := flags.Arg(0)
 			fileContent, err := readFile(filename)
 			if err != nil {
@@ -52,7 +53,7 @@ func Rate() api.Builder {
 			}
 
 			return &api.Trigger{
-				Trigger:     newStagesWorker(runnableStages.stages),
+				Trigger:     newStagesWorker(runnableStages.stages, tracer),
 				DryRun:      newDryRun(runnableStages.stages),
 				Description: fmt.Sprintf("%d different stages", len(runnableStages.stages)),
 				Duration:    runnableStages.stagesTotalDuration,

--- a/internal/trigger/gaussian/gaussian_rate.go
+++ b/internal/trigger/gaussian/gaussian_rate.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
+	"github.com/form3tech-oss/f1/v2/internal/trace"
 	"github.com/form3tech-oss/f1/v2/internal/trigger/api"
 	"github.com/form3tech-oss/f1/v2/internal/trigger/rate"
 )
@@ -33,7 +34,7 @@ func Rate() api.Builder {
 		Name:        "gaussian <scenario>",
 		Description: "distributes load to match a desired monthly volume",
 		Flags:       flags,
-		New: func(flags *pflag.FlagSet) (*api.Trigger, error) {
+		New: func(flags *pflag.FlagSet, tracer trace.Tracer) (*api.Trigger, error) {
 			volume, err := flags.GetFloat64("volume")
 			if err != nil {
 				return nil, fmt.Errorf("getting flag: %w", err)
@@ -89,7 +90,7 @@ func Rate() api.Builder {
 			}
 
 			return &api.Trigger{
-					Trigger: api.NewIterationWorker(rates.IterationDuration, rates.Rate),
+					Trigger: api.NewIterationWorker(rates.IterationDuration, rates.Rate, tracer),
 					DryRun:  rates.Rate,
 					Description: fmt.Sprintf(
 						"Gaussian distribution triggering %d iterations per %s, peaking at %s with standard deviation of %s%s, using distribution %s",

--- a/internal/trigger/ramp/ramp_rate.go
+++ b/internal/trigger/ramp/ramp_rate.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"github.com/form3tech-oss/f1/v2/internal/trace"
 	"github.com/form3tech-oss/f1/v2/internal/trigger/api"
 	"github.com/form3tech-oss/f1/v2/internal/trigger/rate"
 )
@@ -23,7 +24,7 @@ func Rate() api.Builder {
 		Name:        "ramp <scenario>",
 		Description: "ramp up or down requests for a certain duration",
 		Flags:       flags,
-		New: func(flags *pflag.FlagSet) (*api.Trigger, error) {
+		New: func(flags *pflag.FlagSet, tracer trace.Tracer) (*api.Trigger, error) {
 			startRateArg, err := flags.GetString("start-rate")
 			if err != nil {
 				return nil, fmt.Errorf("getting flag: %w", err)
@@ -57,7 +58,7 @@ func Rate() api.Builder {
 			}
 
 			return &api.Trigger{
-				Trigger:     api.NewIterationWorker(rates.IterationDuration, rates.Rate),
+				Trigger:     api.NewIterationWorker(rates.IterationDuration, rates.Rate, tracer),
 				Description: fmt.Sprintf("starting iterations from %s to %s during %v, using distribution %s", startRateArg, endRateArg, duration, distributionTypeArg),
 				DryRun:      rates.Rate,
 			}, nil

--- a/internal/trigger/staged/staged_rate.go
+++ b/internal/trigger/staged/staged_rate.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"github.com/form3tech-oss/f1/v2/internal/trace"
 	"github.com/form3tech-oss/f1/v2/internal/trigger/api"
 )
 
@@ -20,7 +21,7 @@ func Rate() api.Builder {
 		Name:        "staged <scenario>",
 		Description: "triggers iterations at varying rates",
 		Flags:       flags,
-		New: func(params *pflag.FlagSet) (*api.Trigger, error) {
+		New: func(params *pflag.FlagSet, tracer trace.Tracer) (*api.Trigger, error) {
 			jitterArg, err := params.GetFloat64("jitter")
 			if err != nil {
 				return nil, fmt.Errorf("getting flag: %w", err)
@@ -44,7 +45,7 @@ func Rate() api.Builder {
 			}
 
 			return &api.Trigger{
-					Trigger:     api.NewIterationWorker(rates.IterationDuration, rates.Rate),
+					Trigger:     api.NewIterationWorker(rates.IterationDuration, rates.Rate, tracer),
 					DryRun:      rates.Rate,
 					Description: fmt.Sprintf("Starting iterations every %s in numbers varying by time: %s, using distribution %s", frequency, stg, distributionTypeArg),
 					Duration:    rates.Duration,

--- a/internal/trigger/users/users_rate.go
+++ b/internal/trigger/users/users_rate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/form3tech-oss/f1/v2/internal/options"
+	"github.com/form3tech-oss/f1/v2/internal/trace"
 	"github.com/form3tech-oss/f1/v2/internal/trigger/api"
 )
 
@@ -16,7 +17,7 @@ func Rate() api.Builder {
 		Name:        "users <scenario>",
 		Description: "triggers test iterations from a static set of users controlled by the --concurrency flag",
 		Flags:       flags,
-		New: func(*pflag.FlagSet) (*api.Trigger, error) {
+		New: func(*pflag.FlagSet, trace.Tracer) (*api.Trigger, error) {
 			trigger := func(workTriggered chan<- bool, stop <-chan bool, workDone <-chan bool, options options.RunOptions) {
 				doWork := NewWorker(options.Concurrency)
 				doWork(workTriggered, stop, workDone, options)

--- a/pkg/f1/f1_scenarios.go
+++ b/pkg/f1/f1_scenarios.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/form3tech-oss/f1/v2/internal/envsettings"
 	"github.com/form3tech-oss/f1/v2/pkg/f1/scenarios"
 	"github.com/form3tech-oss/f1/v2/pkg/f1/testing"
 )
@@ -14,6 +15,7 @@ import (
 type F1 struct {
 	scenarios *scenarios.Scenarios
 	profiling *profiling
+	settings  envsettings.Settings
 }
 
 // Instantiates a new instance of an F1 CLI.
@@ -21,6 +23,7 @@ func New() *F1 {
 	return &F1{
 		scenarios: scenarios.New(),
 		profiling: &profiling{},
+		settings:  envsettings.Get(),
 	}
 }
 
@@ -47,7 +50,7 @@ func (f *F1) Add(name string, scenarioFn testing.ScenarioFn, options ...scenario
 }
 
 func (f *F1) execute(args []string) error {
-	rootCmd, err := buildRootCmd(f.scenarios, f.profiling)
+	rootCmd, err := buildRootCmd(f.scenarios, f.settings, f.profiling)
 	if err != nil {
 		return fmt.Errorf("building root command: %w", err)
 	}


### PR DESCRIPTION
Currently env variable based settings are scatterred all over the codebase. Making it difficult to track exactly how to configure f1.

Changes:
 - Introduce a `NilTracer` if tracing is disabled to avoid syscalls on every trace event.
 - Centralise all enviroment variable settings
 - Replace panics with error handling
 - Add documentation about the env variables
 - Remove reference to internal `form3tech/k6` in the tracing