### PR TITLE
chore: rework templating & remove go-ataman

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
 	github.com/wcharczuk/go-chart/v2 v2.1.1
-	github.com/workanator/go-ataman v0.0.0-20201223053433-503c6ff9de7d
 	go.uber.org/goleak v1.3.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -40,5 +39,4 @@ require (
 	golang.org/x/image v0.15.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
-	gopkg.in/workanator/go-ataman.v1 v1.0.0-20201223053604-e3b73d2e8108 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,6 @@ github.com/tinylib/msgp v1.1.9 h1:SHf3yoO2sGA0veCJeCBYLHuttAVFHGm2RHgNodW7wQU=
 github.com/tinylib/msgp v1.1.9/go.mod h1:BCXGB54lDD8qUEPmiG0cQQUANC4IUQyB2ItS2UDlO/k=
 github.com/wcharczuk/go-chart/v2 v2.1.1 h1:2u7na789qiD5WzccZsFz4MJWOJP72G+2kUuJoSNqWnE=
 github.com/wcharczuk/go-chart/v2 v2.1.1/go.mod h1:CyCAUt2oqvfhCl6Q5ZvAZwItgpQKZOkCJGb+VGv6l14=
-github.com/workanator/go-ataman v0.0.0-20201223053433-503c6ff9de7d h1:cBuYjhruj/NaYF6xW+rNlGsP2NlML6eK0bSmT/TqpSc=
-github.com/workanator/go-ataman v0.0.0-20201223053433-503c6ff9de7d/go.mod h1:rsS74h4LIZjQz1ooTmjqMxfVYTjuB/E4MrSMvTCOnNI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
@@ -112,8 +110,6 @@ google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHh
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/workanator/go-ataman.v1 v1.0.0-20201223053604-e3b73d2e8108 h1:IytDgf4qdiKn/7v1dLcsogLSV80Io/hbXyPwGM0FUAg=
-gopkg.in/workanator/go-ataman.v1 v1.0.0-20201223053604-e3b73d2e8108/go.mod h1:h7Rt1c9l+3XJeNnAkW4QwJk0FiZhbJJo0VlXbnQL9YU=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/run/output.go
+++ b/internal/run/output.go
@@ -3,32 +3,7 @@ package run
 import (
 	"strings"
 	"text/template"
-	"time"
-
-	"github.com/hako/durafmt"
-	"github.com/workanator/go-ataman"
 )
-
-var templateFunctions = template.FuncMap{
-	"add": func(i, j uint64) uint64 {
-		return i + j
-	},
-	"rate": func(duration time.Duration, count uint64) uint64 {
-		if uint64(duration/time.Second) == 0 {
-			return 0
-		}
-		return count / uint64(duration/time.Second)
-	},
-	"durationSeconds": func(t time.Duration) time.Duration {
-		return t.Round(time.Second)
-	},
-	"duration": func(t time.Duration) string {
-		return durafmt.Parse(t).String()
-	},
-	"percent": func(val, total uint64) float64 {
-		return 100.0 * float64(val) / float64(total)
-	},
-}
 
 func renderTemplate(t *template.Template, r interface{}) string {
 	var builder strings.Builder
@@ -36,6 +11,5 @@ func renderTemplate(t *template.Template, r interface{}) string {
 	if err != nil {
 		panic(err)
 	}
-	rndr := ataman.NewRenderer(ataman.CurlyStyle())
-	return rndr.MustRenderf(builder.String())
+	return builder.String()
 }

--- a/internal/run/result.go
+++ b/internal/run/result.go
@@ -6,28 +6,31 @@ import (
 	"log"
 	"strings"
 	"sync"
-	"text/template"
 	"time"
 
 	io_prometheus_client "github.com/prometheus/client_model/go"
+
+	"github.com/form3tech-oss/f1/v2/internal/run/templates"
 )
 
 type Result struct {
-	mu                           sync.RWMutex
-	errors                       []error
+	mu        sync.RWMutex
+	errors    []error
+	startTime time.Time
+	templates *templates.Templates
+
 	SuccessfulIterationCount     uint64
 	SuccessfulIterationDurations DurationPercentileMap
 	FailedIterationCount         uint64
 	FailedIterationDurations     DurationPercentileMap
 	MaxFailedIterations          int
 	MaxFailedIterationsRate      int
-	startTime                    time.Time
 	TestDuration                 time.Duration
-	LogFile                      string
 	IgnoreDropped                bool
 	DroppedIterationCount        uint64
 	RecentSuccessfulIterations   uint64
 	RecentDuration               time.Duration
+	LogFile                      string
 }
 
 func (r *Result) SetMetrics(result string, stage string, count uint64, quantiles []*io_prometheus_client.Quantile) {
@@ -121,56 +124,10 @@ func parseQuantiles(quantiles []*io_prometheus_client.Quantile) DurationPercenti
 	return m
 }
 
-var (
-	resultTemplate = template.Must(template.New("result parse").
-			Funcs(templateFunctions).
-			Parse(`
-{{if .Failed -}}
-{red}{bold}{u}Load Test Failed{-}
-{{- else -}}
-{green}{bold}{u}Load Test Passed{-}
-{{- end}}
-{{- if .Error}}
-{red}Error: {{.Error}}{-}
-{{- end}}
-{{.IterationsStarted}} iterations started in {{duration .Duration}} ({{rate .Duration .IterationsStarted}}/second)
-{{- if .SuccessfulIterationCount}}
-{bold}Successful Iterations:{-} {green}{{.SuccessfulIterationCount}} ({{percent .SuccessfulIterationCount .Iterations | printf "%0.2f"}}%%, {{rate .Duration .SuccessfulIterationCount}}/second){-} {{.SuccessfulIterationDurations.String}}
-{{- end}}
-{{- if .FailedIterationCount}}
-{bold}Failed Iterations:{-} {red}{{.FailedIterationCount}} ({{percent .FailedIterationCount .Iterations | printf "%0.2f"}}%%, {{rate .Duration .FailedIterationCount}}){-} {{.FailedIterationDurations.String}}
-{{- end}}
-{{- if .DroppedIterationCount}}
-{bold}Dropped Iterations:{-} {yellow}{{.DroppedIterationCount}} ({{percent .DroppedIterationCount .Iterations | printf "%0.2f"}}%%, {{rate .Duration .DroppedIterationCount}}){-} (consider increasing --concurrency setting)
-{{- end}}
-{bold}Full logs:{-} {{.LogFile}}
-`))
-	setup = template.Must(template.New("setup").
-		Funcs(templateFunctions).
-		Parse(`{cyan}[Setup]{-}    {{if .Error}}{red}✘ {{.Error}}{-}{{else}}{green}✔{-}{{end}}`))
-
-	progress = template.Must(template.New("result parse").
-			Funcs(templateFunctions).
-			Parse(`{cyan}[{{durationSeconds .Duration | printf "%5s"}}]{-}  {green}✔ {{printf "%5d" .SuccessfulIterationCount}}{-}  {{if .DroppedIterationCount}}{yellow}⦸ {{printf "%5d" .DroppedIterationCount}}{-}  {{end}}{red}✘ {{printf "%5d" .FailedIterationCount}}{-} {light_black}({{rate .RecentDuration .RecentSuccessfulIterations}}/s){-}
-{{- with .SuccessfulIterationDurations}}   p(50): {{.Get 0.5}},  p(95): {{.Get 0.95}}, p(100): {{.Get 1.0}}{{end}}`))
-	teardown = template.Must(template.New("teardown").
-			Funcs(templateFunctions).
-			Parse(`{cyan}[Teardown]{-} {{if .Error}}{red}✘ {{.Error}}{-}{{else}}{green}✔{-}{{end}}`))
-	timeout = template.Must(template.New("timeout").
-		Funcs(templateFunctions).
-		Parse(`{cyan}[{{durationSeconds .Duration | printf "%5s"}}]  Max Duration Elapsed - waiting for active tests to complete{-}`))
-	maxIterationsReached = template.Must(template.New("maxIterationsReached").
-				Funcs(templateFunctions).
-				Parse(`{cyan}[{{durationSeconds .Duration | printf "%5s"}}]  Max Iterations Reached - waiting for active tests to complete{-}`))
-	interrupt = template.Must(template.New("interrupt").
-			Funcs(templateFunctions).
-			Parse(`{cyan}[{{durationSeconds .Duration | printf "%5s"}}]  Interrupted - waiting for active tests to complete{-}`))
-)
-
 func (r *Result) String() string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return renderTemplate(resultTemplate, r)
+	return renderTemplate(r.templates.Result, r)
 }
 
 func (r *Result) Failed() bool {
@@ -187,7 +144,7 @@ func (r *Result) Failed() bool {
 func (r *Result) Progress() string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return renderTemplate(progress, r)
+	return renderTemplate(r.templates.Progress, r)
 }
 
 func (r *Result) Duration() time.Duration {
@@ -201,25 +158,25 @@ func (r *Result) Duration() time.Duration {
 func (r *Result) Setup() string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return renderTemplate(setup, r)
+	return renderTemplate(r.templates.Setup, r)
 }
 
 func (r *Result) Teardown() string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return renderTemplate(teardown, r)
+	return renderTemplate(r.templates.Teardown, r)
 }
 
 func (r *Result) MaxDurationElapsed() string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return renderTemplate(timeout, r)
+	return renderTemplate(r.templates.Timeout, r)
 }
 
 func (r *Result) Interrupted() string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return renderTemplate(interrupt, r)
+	return renderTemplate(r.templates.Interrupt, r)
 }
 
 func (r *Result) Iterations() uint64 {
@@ -253,5 +210,5 @@ func (r *Result) RecordTestFinished() {
 func (r *Result) MaxIterationsReached() string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return renderTemplate(maxIterationsReached, r)
+	return renderTemplate(r.templates.MaxIterationsReached, r)
 }

--- a/internal/run/templates/templates.go
+++ b/internal/run/templates/templates.go
@@ -1,0 +1,146 @@
+package templates
+
+import (
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/hako/durafmt"
+
+	"github.com/form3tech-oss/f1/v2/internal/termcolor"
+)
+
+const (
+	startTemplate = `{u}{bold}{intensive_blue}F1 Load Tester{-}
+Running {yellow}{{.Options.Scenario}}{-} scenario for {{if .Options.MaxIterations}}up to {{.Options.MaxIterations}} iterations or up to {{end}}{{duration .Options.MaxDuration}} at a rate of {{.RateDescription}}.
+`
+
+	resultTemplate = `
+{{if .Failed -}}
+{red}{bold}{u}Load Test Failed{-}
+{{- else -}}
+{green}{bold}{u}Load Test Passed{-}
+{{- end}}
+{{- if .Error}}
+{red}Error: {{.Error}}{-}
+{{- end}}
+{{.IterationsStarted}} iterations started in {{duration .Duration}} ({{rate .Duration .IterationsStarted}}/second)
+{{- if .SuccessfulIterationCount}}
+{bold}Successful Iterations:{-} {green}{{.SuccessfulIterationCount}} ({{percent .SuccessfulIterationCount .Iterations | printf "%0.2f"}}%, {{rate .Duration .SuccessfulIterationCount}}/second){-} {{.SuccessfulIterationDurations.String}}
+{{- end}}
+{{- if .FailedIterationCount}}
+{bold}Failed Iterations:{-} {red}{{.FailedIterationCount}} ({{percent .FailedIterationCount .Iterations | printf "%0.2f"}}%, {{rate .Duration .FailedIterationCount}}){-} {{.FailedIterationDurations.String}}
+{{- end}}
+{{- if .DroppedIterationCount}}
+{bold}Dropped Iterations:{-} {yellow}{{.DroppedIterationCount}} ({{percent .DroppedIterationCount .Iterations | printf "%0.2f"}}%, {{rate .Duration .DroppedIterationCount}}){-} (consider increasing --concurrency setting)
+{{- end}}
+{bold}Full logs:{-} {{.LogFile}}
+`
+
+	progressTemplate = `{cyan}[{{durationSeconds .Duration | printf "%5s"}}]{-}  {green}✔ {{printf "%5d" .SuccessfulIterationCount}}{-}  {{if .DroppedIterationCount}}{yellow}⦸ {{printf "%5d" .DroppedIterationCount}}{-}  {{end}}{red}✘ {{printf "%5d" .FailedIterationCount}}{-} {light_black}({{rate .RecentDuration .RecentSuccessfulIterations}}/s){-}
+{{- with .SuccessfulIterationDurations}}   p(50): {{.Get 0.5}},  p(95): {{.Get 0.95}}, p(100): {{.Get 1.0}}{{end}}`
+
+	setupTemplate    = `{cyan}[Setup]{-}    {{if .Error}}{red}✘ {{.Error}}{-}{{else}}{green}✔{-}{{end}}`
+	teardownTemplate = `{cyan}[Teardown]{-} {{if .Error}}{red}✘ {{.Error}}{-}{{else}}{green}✔{-}{{end}}`
+
+	timeoutTemplate              = `{cyan}[{{durationSeconds .Duration | printf "%5s"}}]  Max Duration Elapsed - waiting for active tests to complete{-}`
+	maxIterationsReachedTemplate = `{cyan}[{{durationSeconds .Duration | printf "%5s"}}]  Max Iterations Reached - waiting for active tests to complete{-}`
+	interruptTemplate            = `{cyan}[{{durationSeconds .Duration | printf "%5s"}}]  Interrupted - waiting for active tests to complete{-}`
+)
+
+type Templates struct {
+	Start                *template.Template
+	Result               *template.Template
+	Setup                *template.Template
+	Progress             *template.Template
+	Teardown             *template.Template
+	Timeout              *template.Template
+	MaxIterationsReached *template.Template
+	Interrupt            *template.Template
+}
+
+func applyReplacements(templateString string, replacements map[string]string) string {
+	res := templateString
+	for replacement, value := range replacements {
+		res = strings.ReplaceAll(res, replacement, value)
+	}
+	return res
+}
+
+func Parse() *Templates {
+	templateFunctions := template.FuncMap{
+		"add": func(i, j uint64) uint64 {
+			return i + j
+		},
+		"rate": func(duration time.Duration, count uint64) uint64 {
+			if uint64(duration/time.Second) == 0 {
+				return 0
+			}
+			return count / uint64(duration/time.Second)
+		},
+		"durationSeconds": func(t time.Duration) time.Duration {
+			return t.Round(time.Second)
+		},
+		"duration": func(t time.Duration) string {
+			return durafmt.Parse(t).String()
+		},
+		"percent": func(val, total uint64) float64 {
+			return 100.0 * float64(val) / float64(total)
+		},
+	}
+
+	replacements := map[string]string{
+		"{-}":              termcolor.Reset,
+		"{u}":              termcolor.Underline,
+		"{bold}":           termcolor.Bold,
+		"{cyan}":           termcolor.Cyan,
+		"{yellow}":         termcolor.Yellow,
+		"{red}":            termcolor.Red,
+		"{green}":          termcolor.Green,
+		"{intensive_blue}": termcolor.BrightBlue,
+		"{light_black}":    termcolor.BrightBlack,
+	}
+
+	start := template.Must(template.New("result parse").
+		Funcs(templateFunctions).
+		Parse(applyReplacements(startTemplate, replacements)))
+
+	result := template.Must(template.New("result parse").
+		Funcs(templateFunctions).
+		Parse(applyReplacements(resultTemplate, replacements)))
+
+	progress := template.Must(template.New("result parse").
+		Funcs(templateFunctions).
+		Parse(applyReplacements(progressTemplate, replacements)))
+
+	setup := template.Must(template.New("setup").
+		Funcs(templateFunctions).
+		Parse(applyReplacements(setupTemplate, replacements)))
+
+	teardown := template.Must(template.New("teardown").
+		Funcs(templateFunctions).
+		Parse(applyReplacements(teardownTemplate, replacements)))
+
+	timeout := template.Must(template.New("timeout").
+		Funcs(templateFunctions).
+		Parse(applyReplacements(timeoutTemplate, replacements)))
+
+	maxIterationsReached := template.Must(template.New("maxIterationsReached").
+		Funcs(templateFunctions).
+		Parse(applyReplacements(maxIterationsReachedTemplate, replacements)))
+
+	interrupt := template.Must(template.New("interrupt").
+		Funcs(templateFunctions).
+		Parse(applyReplacements(interruptTemplate, replacements)))
+
+	return &Templates{
+		Start:                start,
+		Result:               result,
+		Setup:                setup,
+		Progress:             progress,
+		Teardown:             teardown,
+		Timeout:              timeout,
+		MaxIterationsReached: maxIterationsReached,
+		Interrupt:            interrupt,
+	}
+}

--- a/internal/termcolor/termcolor.go
+++ b/internal/termcolor/termcolor.go
@@ -1,0 +1,29 @@
+package termcolor
+
+const (
+	Reset     = "\033[0m"
+	Bold      = "\033[1m"
+	Underline = "\033[4m"
+)
+
+const (
+	Black   = "\033[30m"
+	Red     = "\033[31m"
+	Green   = "\033[32m"
+	Yellow  = "\033[33m"
+	Blue    = "\033[34m"
+	Magenta = "\033[35m"
+	Cyan    = "\033[36m"
+	White   = "\033[37m"
+)
+
+const (
+	BrightBlack   = "\033[90m"
+	BrightRed     = "\033[91m"
+	BrightGreen   = "\033[92m"
+	BrightYellow  = "\033[93m"
+	BrightBlue    = "\033[94m"
+	BrightMagenta = "\033[95m"
+	BrightCyan    = "\033[96m"
+	BrightWhite   = "\033[97m"
+)

--- a/internal/trace/console_tracer.go
+++ b/internal/trace/console_tracer.go
@@ -7,14 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
-)
 
-const (
-	termReset  = "\033[0m"
-	termGray   = "\033[37m"
-	termYellow = "\033[33m"
-	termBlue   = "\033[34m"
-	termRed    = "\033[31m"
+	"github.com/form3tech-oss/f1/v2/internal/termcolor"
 )
 
 type ConsoleTracer struct {
@@ -28,7 +22,7 @@ func NewConsoleTracer(output io.Writer) *ConsoleTracer {
 var _ Tracer = &ConsoleTracer{}
 
 func colorString(s string, c string) string {
-	return c + s + termReset
+	return c + s + termcolor.Reset
 }
 
 func (t *ConsoleTracer) ReceivedFromChannel(name string) {
@@ -55,22 +49,22 @@ func (t *ConsoleTracer) event(message string, args ...any) {
 
 	keywords := []string{"channel", "Channel"}
 
-	fMessage := colorString(fmt.Sprintf(message, args...), termYellow)
+	fMessage := colorString(fmt.Sprintf(message, args...), termcolor.Yellow)
 
 	for _, s := range keywords {
-		fMessage = strings.Replace(fMessage, s, termRed+s+termYellow, 1)
+		fMessage = strings.Replace(fMessage, s, termcolor.Red+s+termcolor.Yellow, 1)
 	}
 
 	fileName := frame.File + strconv.Itoa(frame.Line)
-	fileName = colorString(fileName, termBlue)
+	fileName = colorString(fileName, termcolor.Blue)
 
 	now := time.Now()
 	formattedTime := fmt.Sprintf("%02d:%02d:%02d %02dms",
 		now.Hour(), now.Minute(), now.Second(), now.Nanosecond()/int(time.Millisecond))
 
-	timePart := colorString(fmt.Sprintf("[TRACE - %s]: ", formattedTime), termGray)
-	messagePart := colorString(fMessage+" -> ", termGray)
-	filePart := colorString(fileName, termBlue)
+	timePart := colorString(fmt.Sprintf("[TRACE - %s]: ", formattedTime), termcolor.White)
+	messagePart := colorString(fMessage+" -> ", termcolor.White)
+	filePart := colorString(fileName, termcolor.Blue)
 
 	fmt.Fprintln(t.writer, timePart+messagePart+filePart)
 }


### PR DESCRIPTION
https://github.com/workanator/go-ataman has not been updated in 7 years.

Replace with `strings.ReplaceAll` of the templated terminal colors.

Changes:
 - templates are no longer global
 - do the term color replacement only once when templates are loaded, instead of every render.