### PR TITLE
chore: enable gochecknoglobals linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,7 +43,6 @@ linters:
   - paralleltest
   - gomnd
   - goerr113
-  - gochecknoglobals
   - lll
   - prealloc
   - gocritic

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -63,6 +63,7 @@ type Metrics struct {
 	Progress         *prometheus.SummaryVec
 }
 
+//nolint:gochecknoglobals // metrics are best suited as globals
 var (
 	m    *Metrics
 	once sync.Once


### PR DESCRIPTION
After removing most the global usages we had in:
 - #181
 - #169
 - #166 

We can now enforce the linter that will prevent more globals from being added[ to ease the maintainability](https://github.com/form3tech-oss/f1/issues/183) 