### PR TITLE
chore: redo gauss calculations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.22
 
 require (
 	github.com/avast/retry-go/v4 v4.5.1
-	github.com/chobie/go-gaussian v0.0.0-20150107165016-53c09d90eeaf
 	github.com/evalphobia/logrus_fluent v0.5.4
 	github.com/google/uuid v1.6.0
 	github.com/guptarohit/asciigraph v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4Yn
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chobie/go-gaussian v0.0.0-20150107165016-53c09d90eeaf h1:joIg05jbCevMTHYELK+iU5xNS6FoOEhp9IpFQ5e2B+8=
-github.com/chobie/go-gaussian v0.0.0-20150107165016-53c09d90eeaf/go.mod h1:cTHhhPCN9aDCOgkFM4Pty90DILaV/TrfCRhMtOFCUUI=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/gaussian/gaussian.go
+++ b/internal/gaussian/gaussian.go
@@ -1,0 +1,142 @@
+package gaussian
+
+import (
+	"errors"
+	"math"
+)
+
+const (
+	Sqrt2Pi = 2.50662827463100050241576528481104525300698674060993831662992357 // https://oeis.org/A019727
+)
+
+// Distribution represents a Gaussian(Normal) distribution.
+//
+// The Gaussian distribution(also known as Normal distribution) is a bell-shaped curve that
+// describes the probability of a random value occurring within a specific range.
+//
+//   - mean: the mean (μ) of the distribution (the centre of the bell curve)
+//   - standardDeviation: the standard deviation (σ) of the distribution (the spread of the curve)
+//   - variance: the variance (σ^2) of the distribution
+type Distribution struct {
+	mean              float64
+	standardDeviation float64
+
+	variance float64
+}
+
+// NewDistribution creates a new Gaussian instance.
+//
+// The Gaussian distribution(also known as Normal distribution) is a bell-shaped curve that
+// describes the probability of a random value occurring within a specific range.
+//
+// It's characterized by two parameters:
+//   - mean: the mean (μ) of the distribution (the centre of the bell curve)
+//   - standardDeviation: the standard deviation (σ) of the distribution (the spread of the curve)
+func NewDistribution(mean, standardDeviation float64) (*Distribution, error) {
+	if standardDeviation <= 0.0 {
+		return nil, errors.New("standard deviation must not be negative")
+	}
+
+	return &Distribution{
+		mean:              mean,
+		standardDeviation: standardDeviation,
+		variance:          standardDeviation * standardDeviation,
+	}, nil
+}
+
+// Exponent calculates the core Exponent term in the Gaussian distribution formula.
+//
+// This function is core to calculating the probability density and other related values.
+//
+// The core term of a Gaussian distribution(or normal distribution) is defined as:
+//
+//	e^(-(x - μ)^2 / (2σ^2))
+//
+// Where:
+//   - x: The value at which to evaluate the Gaussian function.
+//   - μ(mu): The mean of the distribution (the centre of the bell curve).
+//   - σ(sigma): The standard deviation of the distribution (controls the spread of the curve).
+//   - σ^2: The variance of the distribution
+//   - e - Mathematical constant [math.E]
+//
+// This Exponent term determines the relative likelihood of a value `x` within the Gaussian
+// distribution.
+//
+//   - The closer `x` to the mean `μ`, the closer the Exponent term gets to 1, indicating higher
+//     probability density.
+//   - As `x` moves away from the mean `μ`, the Exponent term decreases, indicating lower probability
+//     density.
+//   - The standard deviation `σ` controls the spread: Smaller standard deviation leads to sharper
+//     curves with probability density concentrated around the mean.
+func (d *Distribution) Exponent(x float64) float64 {
+	pow2 := (x - d.mean) * (x - d.mean)
+	return math.Exp(-pow2 / (2 * d.variance))
+}
+
+// PDF calculates the probability density function (PDF) at a given value.
+//
+// PDF of a Gaussian distribution is a bell-shaped curve, that describes the relative likelihood of
+// a random variable taking on a specific value.
+// Formula:
+//
+// f(x) = (1 / (σ * √(2π))) * e^(-(x - μ)^2 / (2σ^2))
+//
+// where:
+//   - x: The value for which we want to calculate the probability density.
+//   - μ(mu): The mean of the distribution (the centre of the bell curve).
+//   - σ(sigma): The standard deviation of the distribution (controls the spread of the curve).
+//   - σ^2: The variance of the distribution
+//   - π - Mathematical constant [math.Pi]
+//   - e - Mathematical constant [math.E]
+func (d *Distribution) PDF(x float64) float64 {
+	// Calculate the inverse of the normalisation constant for the normal distribution
+	// The true normalisation constant is: (1 / (σ * √(2π)))
+	m := d.standardDeviation * Sqrt2Pi
+
+	return d.Exponent(x) / m
+}
+
+// CDF calculates the cumulative distribution function (CDF) of the Gaussian distribution.
+//
+// The CDF of a normal (Gaussian) distribution provides the probability of a random value (X) drawn
+// from the distribution will be less than or equal to a specific value x.
+//
+// The CDF of a normal distribution with mean μ and standard deviation σ is typically denoted as:
+// F(x) = P[X ≤ x]
+//
+// F(x) = 0.5 * (1 + erf((x - μ) / (σ * √2)))
+// = 0.5 * erfc(-(x - μ) / (σ * √2))
+//
+// Where:
+//   - x: The value at which to calculate the CDF
+//   - σ(sigma): The standard deviation of the distribution.
+//   - μ(mu): The mean of the distribution.
+//   - erf(z): The error function
+//   - erfc(z): The complementary error function([math.Erfc]) , erfc(z) = 1 - erf(z) ([math.Erf])
+func (d *Distribution) CDF(x float64) float64 {
+	// Transform normal distribution with mean μ and standard deviation σ
+	// to a standard normal distribution with the following formula:
+	//
+	// z = (x - μ) / (σ * √2)
+	//
+	// Standard normal distribution is a special case of the normal distribution with a mean of 0
+	// and a standard deviation of 1.
+	z := (x - d.mean) / (d.standardDeviation * math.Sqrt2)
+
+	// Calculate the CDF
+	//
+	// The complementary error function (erfc), denoted as erfc(z) is a special function defined as
+	// "1 - erf(z)" , where erf(z) is the error function. The error function itself integrates the
+	// probability density function(PDF) of the standard normal distribution. The erfc, on the other
+	// hand, gives the probability that a standard normal random variable falls outside of the
+	// interval [-z, z].
+	//
+	// By using the erfc function with the transformed input z, we can efficiently calculate the CDF
+	// of the original normal distribution.
+	//
+	// Multiply by 0.5 because the Erfc function's output range is typically [0,1], while the CDF of
+	// a normal distribution ranges from 0 (for negative infinity) to 1(for positive infinity)
+	//
+	// Use the Erfc(-z) because the Erfc function typically deals with non-negative arguments
+	return 0.5 * math.Erfc(-z)
+}

--- a/internal/trigger/gaussian/gaussian_rate_bench_test.go
+++ b/internal/trigger/gaussian/gaussian_rate_bench_test.go
@@ -1,0 +1,66 @@
+package gaussian
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Benchmark_calculateVolume(b *testing.B) {
+	tests := []struct {
+		name     string
+		peakTps  string
+		peakTime time.Duration
+		stddev   time.Duration
+	}{
+		{
+			name:     "1400TPS",
+			peakTps:  "1400/s",
+			stddev:   4 * time.Hour,
+			peakTime: 14 * time.Hour,
+		},
+		{
+			name:     "50TPS",
+			peakTps:  "50/s",
+			stddev:   4 * time.Hour,
+			peakTime: 14 * time.Hour,
+		},
+		{
+			name:     "10TPS",
+			peakTps:  "10/s",
+			stddev:   4 * time.Hour,
+			peakTime: 14 * time.Hour,
+		},
+		{
+			name:     "10TPS 2",
+			peakTps:  "100/10s",
+			stddev:   4 * time.Hour,
+			peakTime: 14 * time.Hour,
+		},
+		{
+			name:     "10TPS no unit",
+			peakTps:  "10",
+			stddev:   4 * time.Hour,
+			peakTime: 14 * time.Hour,
+		},
+		{
+			name:     "1TPms",
+			peakTps:  "1/ms",
+			stddev:   4 * time.Hour,
+			peakTime: 14 * time.Hour,
+		},
+		{
+			name:     "1000TPms",
+			peakTps:  "1000/ms",
+			stddev:   4 * time.Hour,
+			peakTime: 14 * time.Hour,
+		},
+	}
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			_, err := calculateVolume(tt.peakTps, tt.peakTime, tt.stddev)
+			require.NoError(b, err)
+		})
+	}
+}


### PR DESCRIPTION
Replace https://github.com/chobie/go-gaussian with custom implementation.

Changes:
 - go-gausian uses a custom `Erfc` function, that is slower than the one in the `math`. The custom implementatation calculates an approximation of the complementary error function using a polinomial. https://github.com/chobie/go-gaussian/blob/53c09d90eeaff40b27cd89352937d02d57dac506/gaussian.go#L43-L55
 - Use constants for sqrt of 2 and sqrt of 2*Pi
 - Avoid math.Pow(x, 2) and just multiply
 - Avoid math.Sqrt by providing the standard deviation instead of the variance
 - Carefullly document

```
→ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/form3tech-oss/f1/v2/internal/trigger/gaussian
                                  │     old.txt     │             new.txt              │
                                  │     sec/op      │     sec/op       vs base         │
_calculateVolume/1400TPS-10         0.0018220n ± 0%   0.0006767n ± 0%  -62.86% (n=100)
_calculateVolume/50TPS-10           0.0018215n ± 0%   0.0006759n ± 0%  -62.89% (n=100)
_calculateVolume/10TPS-10           0.0018225n ± 0%   0.0006770n ± 0%  -62.85% (n=100)
_calculateVolume/10TPS_2-10         0.0018215n ± 0%   0.0006773n ± 0%  -62.81% (n=100)
_calculateVolume/10TPS_no_unit-10   0.0018150n ± 0%   0.0006685n ± 0%  -63.17% (n=100)
_calculateVolume/1TPms-10           0.0018230n ± 0%   0.0006772n ± 0%  -62.85% (n=100)
_calculateVolume/1000TPms-10        0.0018220n ± 0%   0.0006766n ± 0%  -62.86% (n=100)
geomean                              0.001821n        0.0006756n       -62.90%
```