### PR TITLE
chore: inject printer to allow output stream redirect

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,6 @@ linters:
   - paralleltest
   - gomnd
   - goerr113
-  - forbidigo
 
 linters-settings:
   tagliatelle:

--- a/internal/chart/chart_cmd_stage_test.go
+++ b/internal/chart/chart_cmd_stage_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/form3tech-oss/f1/v2/internal/console"
 	"github.com/form3tech-oss/f1/v2/internal/trace"
 	"github.com/form3tech-oss/f1/v2/internal/trigger"
 )
@@ -33,7 +34,7 @@ func (s *ChartTestStage) and() *ChartTestStage {
 }
 
 func (s *ChartTestStage) i_execute_the_chart_command() *ChartTestStage {
-	cmd := Cmd(trigger.GetBuilders(), trace.NewConsoleTracer(io.Discard))
+	cmd := Cmd(trigger.GetBuilders(), trace.NewConsoleTracer(io.Discard), console.NewPrinter(io.Discard))
 	cmd.SetArgs(s.args)
 	s.err = cmd.Execute()
 	return s

--- a/internal/console/printer.go
+++ b/internal/console/printer.go
@@ -1,0 +1,28 @@
+package console
+
+import (
+	"fmt"
+	"io"
+)
+
+type Printer struct {
+	writer io.Writer
+}
+
+func NewPrinter(writer io.Writer) *Printer {
+	return &Printer{
+		writer: writer,
+	}
+}
+
+func (t *Printer) Println(a ...any) {
+	fmt.Fprintln(t.writer, a...)
+}
+
+func (t *Printer) Printf(format string, a ...any) {
+	fmt.Fprintf(t.writer, format, a...)
+}
+
+func (t *Printer) Print(a ...any) {
+	fmt.Fprint(t.writer, a...)
+}

--- a/internal/run/run_cmd.go
+++ b/internal/run/run_cmd.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/form3tech-oss/f1/v2/internal/console"
 	"github.com/form3tech-oss/f1/v2/internal/envsettings"
 	"github.com/form3tech-oss/f1/v2/internal/logging"
 	"github.com/form3tech-oss/f1/v2/internal/options"
@@ -21,6 +22,7 @@ func Cmd(
 	settings envsettings.Settings,
 	hookFunc logging.RegisterLogHookFunc,
 	tracer trace.Tracer,
+	printer *console.Printer,
 ) *cobra.Command {
 	runCmd := &cobra.Command{
 		Use:   "run <subcommand>",
@@ -32,7 +34,7 @@ func Cmd(
 			triggerCmd := &cobra.Command{
 				Use:   t.Name,
 				Short: t.Description,
-				RunE:  runCmdExecute(s, t, settings, hookFunc, tracer),
+				RunE:  runCmdExecute(s, t, settings, hookFunc, tracer, printer),
 				Args:  cobra.MatchAll(cobra.ExactArgs(1)),
 			}
 			triggerCmd.Flags().BoolP("verbose", "v", false, "enables log output to stdout")
@@ -44,7 +46,7 @@ func Cmd(
 			triggerCmd := &cobra.Command{
 				Use:       t.Name,
 				Short:     t.Description,
-				RunE:      runCmdExecute(s, t, settings, hookFunc, tracer),
+				RunE:      runCmdExecute(s, t, settings, hookFunc, tracer, printer),
 				Args:      cobra.MatchAll(cobra.ExactArgs(1)),
 				ValidArgs: s.GetScenarioNames(),
 			}
@@ -77,6 +79,7 @@ func runCmdExecute(
 	settings envsettings.Settings,
 	hookFunc logging.RegisterLogHookFunc,
 	tracer trace.Tracer,
+	printer *console.Printer,
 ) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
@@ -150,7 +153,7 @@ func runCmdExecute(
 			MaxFailuresRate:     maxFailuresRate,
 			RegisterLogHookFunc: hookFunc,
 			IgnoreDropped:       ignoreDropped,
-		}, trig, settings, tracer)
+		}, trig, settings, tracer, printer)
 		if err != nil {
 			return fmt.Errorf("new run: %w", err)
 		}

--- a/internal/support/errorh/handler.go
+++ b/internal/support/errorh/handler.go
@@ -1,7 +1,6 @@
 package errorh
 
 import (
-	"fmt"
 	"io"
 
 	log "github.com/sirupsen/logrus"
@@ -10,12 +9,6 @@ import (
 func Log(err error, message string) {
 	if err != nil {
 		log.WithError(err).Error(message)
-	}
-}
-
-func Print(err error, message string) {
-	if err != nil {
-		fmt.Printf("%s: %s", message, err)
 	}
 }
 

--- a/pkg/f1/f1_scenarios.go
+++ b/pkg/f1/f1_scenarios.go
@@ -77,7 +77,7 @@ func (f *F1) execute(args []string) error {
 // function.
 func (f *F1) Execute() {
 	if err := f.execute(nil); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/pkg/f1/root_cmd.go
+++ b/pkg/f1/root_cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/form3tech-oss/f1/v2/internal/chart"
+	"github.com/form3tech-oss/f1/v2/internal/console"
 	"github.com/form3tech-oss/f1/v2/internal/envsettings"
 	"github.com/form3tech-oss/f1/v2/internal/fluentd"
 	"github.com/form3tech-oss/f1/v2/internal/run"
@@ -43,14 +44,17 @@ func buildRootCmd(s *scenarios.Scenarios, settings envsettings.Settings, p *prof
 		tracer = trace.NewConsoleTracer(os.Stdout)
 	}
 
+	printer := console.NewPrinter(os.Stdout)
+
 	rootCmd.AddCommand(run.Cmd(
 		s,
 		builders,
 		settings,
 		fluentd.LoggingHook(settings.Fluentd.Host, settings.Fluentd.Port),
 		tracer,
+		printer,
 	))
-	rootCmd.AddCommand(chart.Cmd(builders, tracer))
+	rootCmd.AddCommand(chart.Cmd(builders, tracer, printer))
 	rootCmd.AddCommand(scenarios.Cmd(s))
 	rootCmd.AddCommand(completionsCmd(rootCmd))
 	return rootCmd, nil

--- a/pkg/f1/scenarios/scenarios_cmd.go
+++ b/pkg/f1/scenarios/scenarios_cmd.go
@@ -1,10 +1,12 @@
 package scenarios
 
 import (
-	"fmt"
+	"os"
 	"sort"
 
 	"github.com/spf13/cobra"
+
+	"github.com/form3tech-oss/f1/v2/internal/console"
 )
 
 func Cmd(s *Scenarios) *cobra.Command {
@@ -12,24 +14,27 @@ func Cmd(s *Scenarios) *cobra.Command {
 		Use:   "scenarios",
 		Short: "Prints information about available test scenarios",
 	}
-	scenariosCmd.AddCommand(lsCmd(s))
+
+	// this should be injected, but it's a breaking changes for v2
+	printer := console.NewPrinter(os.Stdout)
+	scenariosCmd.AddCommand(lsCmd(s, printer))
 	return scenariosCmd
 }
 
-func lsCmd(s *Scenarios) *cobra.Command {
+func lsCmd(s *Scenarios, printer *console.Printer) *cobra.Command {
 	lsCmd := &cobra.Command{
 		Use: "ls",
-		Run: lsCmdExecute(s),
+		Run: lsCmdExecute(s, printer),
 	}
 	return lsCmd
 }
 
-func lsCmdExecute(s *Scenarios) func(*cobra.Command, []string) {
+func lsCmdExecute(s *Scenarios, printer *console.Printer) func(*cobra.Command, []string) {
 	return func(*cobra.Command, []string) {
 		scenarios := s.GetScenarioNames()
 		sort.Strings(scenarios)
 		for _, scenario := range scenarios {
-			fmt.Println(scenario)
+			printer.Println(scenario)
 		}
 	}
 }


### PR DESCRIPTION
avoid raw `fmt.Print*` funcs to allow capturing ouput without globals