### PR TITLE
chore: constant flag names

### DIFF
--- a/internal/chart/chart_cmd.go
+++ b/internal/chart/chart_cmd.go
@@ -15,6 +15,12 @@ import (
 	"github.com/form3tech-oss/f1/v2/internal/trigger/api"
 )
 
+const (
+	flagChartStart    = "chart-start"
+	flagChartDuration = "chart-duration"
+	flagFilename      = "filename"
+)
+
 func Cmd(builders []api.Builder, tracer trace.Tracer, printer *console.Printer) *cobra.Command {
 	chartCmd := &cobra.Command{
 		Use:   "chart <subcommand>",
@@ -27,9 +33,9 @@ func Cmd(builders []api.Builder, tracer trace.Tracer, printer *console.Printer) 
 			Short: t.Description,
 			RunE:  chartCmdExecute(t, tracer, printer),
 		}
-		triggerCmd.Flags().String("chart-start", time.Now().Format(time.RFC3339), "Optional start time for the chart")
-		triggerCmd.Flags().Duration("chart-duration", 10*time.Minute, "Duration for the chart")
-		triggerCmd.Flags().String("filename", "", fmt.Sprintf("Filename for optional detailed chart, e.g. %s.png", t.Name))
+		triggerCmd.Flags().String(flagChartStart, time.Now().Format(time.RFC3339), "Optional start time for the chart")
+		triggerCmd.Flags().Duration(flagChartDuration, 10*time.Minute, "Duration for the chart")
+		triggerCmd.Flags().String(flagFilename, "", fmt.Sprintf("Filename for optional detailed chart, e.g. %s.png", t.Name))
 		triggerCmd.Flags().AddFlagSet(t.Flags)
 		chartCmd.AddCommand(triggerCmd)
 	}
@@ -45,7 +51,7 @@ func chartCmdExecute(
 	return func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
 
-		startString, err := cmd.Flags().GetString("chart-start")
+		startString, err := cmd.Flags().GetString(flagChartStart)
 		if err != nil {
 			return fmt.Errorf("getting flag: %w", err)
 		}
@@ -53,11 +59,11 @@ func chartCmdExecute(
 		if err != nil {
 			return fmt.Errorf("parsing start time: %w", err)
 		}
-		duration, err := cmd.Flags().GetDuration("chart-duration")
+		duration, err := cmd.Flags().GetDuration(flagChartDuration)
 		if err != nil {
 			return fmt.Errorf("getting flag: %w", err)
 		}
-		filename, err := cmd.Flags().GetString("filename")
+		filename, err := cmd.Flags().GetString(flagFilename)
 		if err != nil {
 			return fmt.Errorf("getting flag: %w", err)
 		}

--- a/internal/run/active_scenario.go
+++ b/internal/run/active_scenario.go
@@ -61,5 +61,5 @@ func (s *ActiveScenario) Run(metric metrics.MetricType, stage, iter string, f fu
 }
 
 func (s *ActiveScenario) RecordDroppedIteration() {
-	s.m.Record(metrics.IterationResult, s.scenario.Name, IterationStage, "dropped", 0)
+	s.m.Record(metrics.IterationResult, s.scenario.Name, IterationStage, metrics.DroppedResult, 0)
 }

--- a/internal/run/templates/templates.go
+++ b/internal/run/templates/templates.go
@@ -100,15 +100,15 @@ func Parse() *Templates {
 		"{light_black}":    termcolor.BrightBlack,
 	}
 
-	start := template.Must(template.New("result parse").
+	start := template.Must(template.New("start").
 		Funcs(templateFunctions).
 		Parse(applyReplacements(startTemplate, replacements)))
 
-	result := template.Must(template.New("result parse").
+	result := template.Must(template.New("result").
 		Funcs(templateFunctions).
 		Parse(applyReplacements(resultTemplate, replacements)))
 
-	progress := template.Must(template.New("result parse").
+	progress := template.Must(template.New("progress").
 		Funcs(templateFunctions).
 		Parse(applyReplacements(progressTemplate, replacements)))
 

--- a/internal/trigger/api/iteration_distribution.go
+++ b/internal/trigger/api/iteration_distribution.go
@@ -7,18 +7,26 @@ import (
 	"time"
 )
 
+type DistributionType string
+
+const (
+	NoneDistribution    DistributionType = "none"
+	RegularDistribution DistributionType = "regular"
+	RandomDistribution  DistributionType = "random"
+)
+
 func NewDistribution(
-	distributionTypeArg string,
+	distributionTypeArg DistributionType,
 	iterationDuration time.Duration,
 	rateFn RateFunction,
 ) (time.Duration, RateFunction, error) {
 	switch distributionTypeArg {
-	case "none":
+	case NoneDistribution:
 		return iterationDuration, rateFn, nil
-	case "regular":
+	case RegularDistribution:
 		distributedIterationDuration, distributedRateFn := withRegularDistribution(iterationDuration, rateFn)
 		return distributedIterationDuration, distributedRateFn, nil
-	case "random":
+	case RandomDistribution:
 		randomFn := rand.Intn
 		distributedIterationDuration, distributedRateFn := withRandomDistribution(iterationDuration, rateFn, randomFn)
 		return distributedIterationDuration, distributedRateFn, nil

--- a/internal/trigger/rate/rate.go
+++ b/internal/trigger/rate/rate.go
@@ -19,7 +19,7 @@ func ParseRate(rateArg string) (int, time.Duration, error) {
 			return rate, unit, fmt.Errorf("unable to parse rate %s: %w", rateArg, err)
 		}
 		if rate < 0 {
-			return rate, unit, fmt.Errorf("invalid rate arg %s", rateArg)
+			return rate, unit, fmt.Errorf("rate %s can't be negative", rateArg)
 		}
 		unitArg := (rateArg)[strings.Index(rateArg, "/")+1:]
 		if !isNumeric(unitArg[0:1]) {
@@ -36,7 +36,7 @@ func ParseRate(rateArg string) (int, time.Duration, error) {
 			return rate, unit, fmt.Errorf("unable to parse rate %s: %w", rateArg, err)
 		}
 		if rate < 0 {
-			return rate, unit, fmt.Errorf("invalid rate arg %s", rateArg)
+			return rate, unit, fmt.Errorf("rate %s can't be negative", rateArg)
 		}
 		unit = 1 * time.Second
 	}

--- a/internal/trigger/staged/staged_rate.go
+++ b/internal/trigger/staged/staged_rate.go
@@ -8,6 +8,12 @@ import (
 
 	"github.com/form3tech-oss/f1/v2/internal/trace"
 	"github.com/form3tech-oss/f1/v2/internal/trigger/api"
+	"github.com/form3tech-oss/f1/v2/internal/triggerflags"
+)
+
+const (
+	flagStages             = "stages"
+	flagIterationFrequency = "iterationFrequency"
 )
 
 func Rate() api.Builder {
@@ -15,31 +21,30 @@ func Rate() api.Builder {
 	flags.StringP("stages", "s", "0s:1, 10s:1",
 		"Comma separated list of <stage_duration>:<target_concurrent_iterations>. "+
 			"During the stage, the number of concurrent iterations will ramp up or down to the target.")
-	flags.DurationP("iterationFrequency", "f", 1*time.Second,
+	flags.DurationP(flagIterationFrequency, "f", 1*time.Second,
 		"How frequently iterations should be started")
-	flags.Float64P("jitter", "j", 0.0,
-		"vary the rate randomly by up to jitter percent")
-	flags.String("distribution", "regular",
-		"optional parameter to distribute the rate over steps of 100ms, which can be none|regular|random")
+
+	triggerflags.JitterFlag(flags)
+	triggerflags.DistributionFlag(flags)
 
 	return api.Builder{
 		Name:        "staged <scenario>",
 		Description: "triggers iterations at varying rates",
 		Flags:       flags,
 		New: func(params *pflag.FlagSet, tracer trace.Tracer) (*api.Trigger, error) {
-			jitterArg, err := params.GetFloat64("jitter")
+			jitterArg, err := params.GetFloat64(triggerflags.FlagJitter)
 			if err != nil {
 				return nil, fmt.Errorf("getting flag: %w", err)
 			}
-			stg, err := params.GetString("stages")
+			stg, err := params.GetString(flagStages)
 			if err != nil {
 				return nil, fmt.Errorf("getting flag: %w", err)
 			}
-			frequency, err := params.GetDuration("iterationFrequency")
+			frequency, err := params.GetDuration(flagIterationFrequency)
 			if err != nil {
 				return nil, fmt.Errorf("getting flag: %w", err)
 			}
-			distributionTypeArg, err := params.GetString("distribution")
+			distributionTypeArg, err := params.GetString(triggerflags.FlagDistribution)
 			if err != nil {
 				return nil, fmt.Errorf("getting flag: %w", err)
 			}
@@ -75,7 +80,9 @@ func CalculateStagedRate(
 
 	calculator := newRateCalculator(stages)
 	rateFn := api.WithJitter(calculator.Rate, jitterArg)
-	distributedIterationDuration, distributedRateFn, err := api.NewDistribution(distributionTypeArg, frequency, rateFn)
+	distributedIterationDuration, distributedRateFn, err := api.NewDistribution(
+		api.DistributionType(distributionTypeArg), frequency, rateFn,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("new distribution: %w", err)
 	}

--- a/internal/triggerflags/flags.go
+++ b/internal/triggerflags/flags.go
@@ -1,0 +1,41 @@
+package triggerflags
+
+import (
+	"strings"
+
+	"github.com/spf13/pflag"
+
+	"github.com/form3tech-oss/f1/v2/internal/trigger/api"
+)
+
+const (
+	FlagVerbose         = "verbose"
+	FlagVerboseFail     = "verbose-fail"
+	FlagIgnoreDropped   = "ignore-dropped"
+	FlagMaxDuration     = "max-duration"
+	FlagMaxIterations   = "max-iterations"
+	FlagConcurrency     = "concurrency"
+	FlagMaxFailures     = "max-failures"
+	FlagMaxFailuresRate = "max-failures-rate"
+)
+
+const FlagDistribution = "distribution"
+
+func DistributionFlag(flagSet *pflag.FlagSet) {
+	distributionTypes := []string{
+		string(api.NoneDistribution),
+		string(api.RegularDistribution),
+		string(api.RandomDistribution),
+	}
+
+	distributions := strings.Join(distributionTypes, "|")
+	flagSet.String(FlagDistribution, string(api.RegularDistribution),
+		"optional parameter to distribute the rate over steps of 100ms, which can be "+distributions)
+}
+
+const FlagJitter = "jitter"
+
+func JitterFlag(flagSet *pflag.FlagSet) {
+	flagSet.Float64P(FlagJitter, "j", 0.0,
+		"vary the rate randomly by up to jitter percent")
+}


### PR DESCRIPTION
 - Extract flag names to constants to avoid possible misalignment between defining the flag and using it.
 - metrics: use constant name for `dropped` instead of string literal
 - rework `run` command flag setup to make it obvious how `IgnoreCommonFlags` is applied.
 - Verbose error when `concurrency` is negative instead of a generic "invalid value".
 - Extract distribution types to constants to avoid possible misalignment.