### PR TITLE
chore: use atomic types instead of function on primitives

### DIFF
--- a/internal/options/run_options.go
+++ b/internal/options/run_options.go
@@ -12,7 +12,7 @@ type RunOptions struct {
 	Concurrency         int
 	Verbose             bool
 	VerboseFail         bool
-	MaxIterations       int32
+	MaxIterations       uint32
 	MaxFailures         int
 	MaxFailuresRate     int
 	RegisterLogHookFunc logging.RegisterLogHookFunc

--- a/internal/run/run_cmd.go
+++ b/internal/run/run_cmd.go
@@ -51,7 +51,7 @@ func Cmd(
 				"--max-duration 1s (stop after 1 second)")
 			triggerCmd.Flags().IntP(triggerflags.FlagConcurrency, "c", 100,
 				"--concurrency 2 (allow at most 2 groups of iterations to run concurrently)")
-			triggerCmd.Flags().Int32P(triggerflags.FlagMaxIterations, "i", 0,
+			triggerCmd.Flags().Uint32P(triggerflags.FlagMaxIterations, "i", 0,
 				"--max-iterations 100 (stop after 100 iterations, regardless of remaining duration)")
 			triggerCmd.Flags().Int(triggerflags.FlagMaxFailures, 0,
 				"--max-failures 10 (load test will fail if more than 10 errors occurred, default is 0)")
@@ -86,7 +86,7 @@ func runCmdExecute(
 		var scenarioName string
 		var duration time.Duration
 		var concurrency int
-		var maxIterations int32
+		var maxIterations uint32
 		var maxFailures int
 		var maxFailuresRate int
 		var ignoreDropped bool
@@ -112,7 +112,7 @@ func runCmdExecute(
 				return fmt.Errorf("concurrency %d can't be less than 1", concurrency)
 			}
 
-			maxIterations, err = cmd.Flags().GetInt32(triggerflags.FlagMaxIterations)
+			maxIterations, err = cmd.Flags().GetUint32(triggerflags.FlagMaxIterations)
 			if err != nil {
 				return fmt.Errorf("getting flag: %w", err)
 			}

--- a/internal/run/run_cmd_test.go
+++ b/internal/run/run_cmd_test.go
@@ -5,13 +5,10 @@ import (
 	"time"
 )
 
-// TestSimpleFlow is equivalent to a single run from TestParameterised. It's useful for debugging individual test runs
 func TestSimpleFlow(t *testing.T) {
-	// t.Skip("Duplicate of Parameterised test. Useful for manual testing when adding new tests or debugging, so leaving in place")
 	given, when, then := NewRunTestStage(t)
 
 	test := TestParam{
-		name:                   "basic test",
 		constantRate:           "10/100ms",
 		testDuration:           100 * time.Millisecond,
 		concurrency:            100,
@@ -60,12 +57,12 @@ type TestParam struct {
 	constantRate              string
 	testDuration              time.Duration
 	expectedRunTime           time.Duration
-	expectedCompletedTests    int32
+	expectedCompletedTests    uint32
 	concurrency               int
 	iterationDuration         time.Duration
 	expectedDroppedIterations uint64
 	expectedFailure           bool
-	maxIterations             int32
+	maxIterations             uint32
 	maxFailures               int
 	maxFailuresRate           int
 	stages                    string
@@ -558,7 +555,7 @@ func TestFinalRunMetrics(t *testing.T) {
 	given.
 		a_rate_of("100/100ms").and().
 		a_duration_of(450 * time.Millisecond).and().
-		a_scenario_where_the_final_iteration_takes_100ms()
+		a_scenario_where_iteration_n_takes_100ms(400)
 
 	when.i_execute_the_run_command()
 

--- a/internal/trigger/api/api.go
+++ b/internal/trigger/api/api.go
@@ -44,7 +44,7 @@ type Options struct {
 	Concurrency     int
 	Verbose         bool
 	VerboseFail     bool
-	MaxIterations   int32
+	MaxIterations   uint32
 	MaxFailures     int
 	MaxFailuresRate int
 	IgnoreDropped   bool

--- a/internal/trigger/file/file_parser.go
+++ b/internal/trigger/file/file_parser.go
@@ -28,7 +28,7 @@ type Schedule struct {
 type Limits struct {
 	MaxDuration     *time.Duration `yaml:"max-duration"`
 	Concurrency     *int           `yaml:"concurrency"`
-	MaxIterations   *int32         `yaml:"max-iterations"`
+	MaxIterations   *uint32        `yaml:"max-iterations"`
 	MaxFailures     *int           `yaml:"max-failures"`
 	MaxFailuresRate *int           `yaml:"max-failures-rate"`
 	IgnoreDropped   *bool          `yaml:"ignore-dropped"`

--- a/internal/trigger/file/file_parser_test.go
+++ b/internal/trigger/file/file_parser_test.go
@@ -661,7 +661,7 @@ type testData struct {
 	expectedIterationDuration time.Duration
 	expectedMaxDuration       time.Duration
 	expectedIgnoreDropped     bool
-	expectedMaxIterations     int32
+	expectedMaxIterations     uint32
 	expectedMaxFailures       int
 	expectedMaxFailuresRate   int
 	expectedConcurrency       int

--- a/internal/trigger/file/file_rate.go
+++ b/internal/trigger/file/file_rate.go
@@ -20,7 +20,7 @@ type runnableStages struct {
 	stagesTotalDuration time.Duration
 	maxDuration         time.Duration
 	concurrency         int
-	maxIterations       int32
+	maxIterations       uint32
 	maxFailures         int
 	maxFailuresRate     int
 	ignoreDropped       bool


### PR DESCRIPTION
Using types makes sure that all the access is protected.

Changes:
  - Change iterations to uint32 instead of int32 (always positive)
  - Minor test stage refactor