### PR TITLE
fix: use the printer output stream instead of os.Stdout

### DIFF
--- a/internal/console/printer.go
+++ b/internal/console/printer.go
@@ -6,23 +6,23 @@ import (
 )
 
 type Printer struct {
-	writer io.Writer
+	Writer io.Writer
 }
 
 func NewPrinter(writer io.Writer) *Printer {
 	return &Printer{
-		writer: writer,
+		Writer: writer,
 	}
 }
 
 func (t *Printer) Println(a ...any) {
-	fmt.Fprintln(t.writer, a...)
+	fmt.Fprintln(t.Writer, a...)
 }
 
 func (t *Printer) Printf(format string, a ...any) {
-	fmt.Fprintf(t.writer, format, a...)
+	fmt.Fprintf(t.Writer, format, a...)
 }
 
 func (t *Printer) Print(a ...any) {
-	fmt.Fprint(t.writer, a...)
+	fmt.Fprint(t.Writer, a...)
 }

--- a/internal/run/logging.go
+++ b/internal/run/logging.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"fmt"
+	"io"
 	stdlog "log"
 	"os"
 	"path/filepath"
@@ -32,7 +33,7 @@ func getLogFilePath(scenario string, logPath string) string {
 	return getGeneratedLogFilePath(scenario)
 }
 
-func redirectLoggingToFile(scenario string, logPath string) string {
+func redirectLoggingToFile(scenario string, logPath string, output io.Writer) string {
 	logFilePath := getLogFilePath(scenario, logPath)
 
 	file, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
@@ -42,6 +43,6 @@ func redirectLoggingToFile(scenario string, logPath string) string {
 		log.Info("Failed to log to file, using default stderr")
 	}
 
-	stdlog.SetOutput(os.Stdout)
+	stdlog.SetOutput(output)
 	return logFilePath
 }

--- a/internal/run/test_runner.go
+++ b/internal/run/test_runner.go
@@ -183,7 +183,7 @@ func (r *Run) configureLogging() error {
 	}
 
 	if !r.Options.Verbose {
-		r.result.LogFile = redirectLoggingToFile(r.Options.Scenario, r.Settings.LogFilePath)
+		r.result.LogFile = redirectLoggingToFile(r.Options.Scenario, r.Settings.LogFilePath, r.printer.Writer)
 		welcomeMessage := renderTemplate(r.templates.Start, r)
 		log.Info(welcomeMessage)
 		r.printer.Printf("Saving logs to %s\n\n", r.result.LogFile)
@@ -197,8 +197,8 @@ func (r *Run) printSummary() {
 	r.printer.Println(summary)
 	if !r.Options.Verbose {
 		log.Info(summary)
-		log.StandardLogger().SetOutput(os.Stdout)
-		stdlog.SetOutput(os.Stdout)
+		log.StandardLogger().SetOutput(r.printer.Writer)
+		stdlog.SetOutput(r.printer.Writer)
 	}
 }
 
@@ -423,7 +423,7 @@ func (r *Run) printResultLogs() error {
 	}()
 
 	if fd != nil {
-		if _, err := io.Copy(os.Stdout, fd); err != nil {
+		if _, err := io.Copy(r.printer.Writer, fd); err != nil {
 			return fmt.Errorf("printing logs: %w", err)
 		}
 	}


### PR DESCRIPTION
Removes more hardcoded usages of os.Stdout for cleaner test output

Part of: #172 