### PR TITLE
chore: fix TestRandomDistribution test

### DIFF
--- a/internal/run/run_cmd_test.go
+++ b/internal/run/run_cmd_test.go
@@ -454,7 +454,7 @@ func TestRandomDistribution(t *testing.T) {
 		a_trigger_type_of(Constant).and().
 		a_rate_of("10/s").and().
 		a_distribution_type("random").and().
-		a_duration_of(500 * time.Millisecond).and().
+		a_duration_of(1 * time.Second).and().
 		a_concurrency_of(50).and().
 		an_iteration_limit_of(1000).and().
 		a_scenario_where_each_iteration_takes(1 * time.Millisecond)


### PR DESCRIPTION
Run the test for longer to allow more samples, as with the current setup, it is possible for all the samples to randomly be distributed in the same 100ms window.

Part of: #182