### PR TITLE
chore: add toolchain to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/form3tech-oss/f1/v2
 
 go 1.22
 
+toolchain go1.22.0
+
 require (
 	github.com/avast/retry-go/v4 v4.5.1
 	github.com/evalphobia/logrus_fluent v0.5.4


### PR DESCRIPTION
Fixes CodeQL warning:
> As of Go 1.21, toolchain versions must use the 1.N.P syntax.
>
> 1.22 in go.mod does not match this syntax and there is no additional toolchain directive, which may cause some go commands to fail.

<img width="1319" alt="Screenshot 2024-04-12 at 07 31 10" src="https://github.com/form3tech-oss/f1/assets/82881913/c3d56807-e600-4e87-837e-9d877c71c212">
