### PR TITLE
chore: add top level token permissions to CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 on: [push]
+permissions:
+  contents: read
 jobs:
   version:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,8 @@ on:
     branches: [ "master"]
   schedule:
     - cron: '39 23 * * 0'
+permissions:
+  contents: read
 
 jobs:
   analyze:


### PR DESCRIPTION
Following:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

Specifying `read` on `contents` implies everything else is `none` by default.

Fixes:
https://github.com/form3tech-oss/f1/security/code-scanning/1
https://github.com/form3tech-oss/f1/security/code-scanning/2