### PR TITLE
chore: use full go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/form3tech-oss/f1/v2
 
-go 1.22
-
-toolchain go1.22.0
+go 1.22.0
 
 require (
 	github.com/avast/retry-go/v4 v4.5.1


### PR DESCRIPTION
Second attempt at fixing codeql warning:
> As of Go 1.21, toolchain versions must use the 1.N.P syntax.

https://go.dev/doc/toolchain#version

Previous attempt: #209