### PR TITLE
fix(tracer): remove variadic arguments

### DIFF
--- a/internal/run/test_runner.go
+++ b/internal/run/test_runner.go
@@ -278,13 +278,13 @@ func (r *Run) doWork(doWorkChannel chan<- uint32, durationElapsed *CancellableTi
 	}
 	iteration := r.iteration.Add(1)
 	if r.Options.MaxIterations > 0 && iteration > r.Options.MaxIterations {
-		r.tracer.Event("Max iterations exceeded Calling Cancel on iteration  '%v' .", iteration)
+		r.tracer.IterationEvent("Max iterations exceeded Calling Cancel", iteration)
 		if durationElapsed.Cancel() {
 			r.printer.Println(r.result.MaxIterationsReached())
 		}
-		r.tracer.Event("Max iterations exceeded Called Cancel on iteration  '%v' .", iteration)
+		r.tracer.IterationEvent("Max iterations exceeded Called Cancel", iteration)
 	} else if r.Options.MaxIterations <= 0 || iteration <= r.Options.MaxIterations {
-		r.tracer.Event("Within Max iterations So calling dowork() on iteration  '%v' .", iteration)
+		r.tracer.IterationEvent("Within Max iterations So calling dowork()", iteration)
 		doWorkChannel <- iteration
 	}
 }
@@ -349,14 +349,14 @@ func (r *Run) runWorker(
 	workDone chan<- bool,
 ) {
 	defer wg.Done()
-	r.tracer.Event("Started worker (%v)", worker)
+	r.tracer.WorkerEvent("Started worker", worker)
 	for {
 		select {
 		case <-stop:
-			r.tracer.Event("Stopping worker (%v)", worker)
+			r.tracer.WorkerEvent("Stopping worker", worker)
 			return
 		case iteration := <-iterationInput:
-			r.tracer.Event("Received work (%v) from Channel 'doWork' iteration (%v)", worker, iteration)
+			r.tracer.IterationEvent("Received work from Channel 'doWork'", iteration)
 			r.busyWorkers.Add(1)
 
 			scenario := r.activeScenario.scenario
@@ -379,7 +379,7 @@ func (r *Run) runWorker(
 				return
 			}
 
-			r.tracer.Event("Completed iteration (%v).", iteration)
+			r.tracer.IterationEvent("Completed iteration", iteration)
 		}
 	}
 }

--- a/internal/trace/console_tracer.go
+++ b/internal/trace/console_tracer.go
@@ -26,22 +26,30 @@ func colorString(s string, c string) string {
 }
 
 func (t *ConsoleTracer) ReceivedFromChannel(name string) {
-	t.event("Received from Channel '%s'", name)
+	t.event(fmt.Sprintf("Received from Channel '%s'", name))
 }
 
 func (t *ConsoleTracer) SentToChannel(name string) {
-	t.event("Sent to Channel '%s'", name)
+	t.event(fmt.Sprintf("Sent to Channel '%s'", name))
 }
 
 func (t *ConsoleTracer) SendingToChannel(name string) {
-	t.event("Sending to Channel '%s'", name)
+	t.event(fmt.Sprintf("Sending to Channel '%s'", name))
 }
 
-func (t *ConsoleTracer) Event(message string, args ...any) {
-	t.event(message, args...)
+func (t *ConsoleTracer) Event(message string) {
+	t.event(message)
 }
 
-func (t *ConsoleTracer) event(message string, args ...any) {
+func (t *ConsoleTracer) IterationEvent(message string, iteration uint32) {
+	t.event(message + fmt.Sprintf(" (iteration: %d)", iteration))
+}
+
+func (t *ConsoleTracer) WorkerEvent(message string, worker string) {
+	t.event(message + fmt.Sprintf(" (worker: %s)", worker))
+}
+
+func (t *ConsoleTracer) event(message string) {
 	pc := make([]uintptr, 15)
 	n := runtime.Callers(3, pc)
 	frames := runtime.CallersFrames(pc[:n])
@@ -49,7 +57,7 @@ func (t *ConsoleTracer) event(message string, args ...any) {
 
 	keywords := []string{"channel", "Channel"}
 
-	fMessage := colorString(fmt.Sprintf(message, args...), termcolor.Yellow)
+	fMessage := colorString(message, termcolor.Yellow)
 
 	for _, s := range keywords {
 		fMessage = strings.Replace(fMessage, s, termcolor.Red+s+termcolor.Yellow, 1)

--- a/internal/trace/nil_tracer.go
+++ b/internal/trace/nil_tracer.go
@@ -17,5 +17,11 @@ func (*NilTracer) SentToChannel(string) {
 func (*NilTracer) SendingToChannel(string) {
 }
 
-func (*NilTracer) Event(string, ...any) {
+func (*NilTracer) Event(string) {
+}
+
+func (*NilTracer) WorkerEvent(string, string) {
+}
+
+func (*NilTracer) IterationEvent(string, uint32) {
 }

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -4,5 +4,7 @@ type Tracer interface {
 	ReceivedFromChannel(name string)
 	SendingToChannel(name string)
 	SentToChannel(name string)
-	Event(message string, args ...any)
+	Event(message string)
+	WorkerEvent(message string, worker string)
+	IterationEvent(message string, iteration uint32)
 }

--- a/pkg/f1/profiling.go
+++ b/pkg/f1/profiling.go
@@ -3,7 +3,6 @@ package f1
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"runtime/pprof"
 )
 
@@ -45,8 +44,6 @@ func (p *profiling) stop() error {
 			return fmt.Errorf("creating memprofile file '%s': %w", p.memProfileFileName, err)
 		}
 		defer f.Close()
-
-		runtime.GC() // get up-to-date statistics
 
 		if err := pprof.WriteHeapProfile(f); err != nil {
 			return fmt.Errorf("writing mem profile: %w", err)


### PR DESCRIPTION
The variadic arguments in Go always lead to an allocation of a slice
before the function call.

To avoid the tracer having memory allocation overhead - use specific
function signatures.


<img width="1916" alt="Screenshot 2024-04-17 at 05 58 14" src="https://github.com/form3tech-oss/f1/assets/82881913/b0f01928-18cc-4128-afbd-8a39fb94b035">



