### PR TITLE
feat(perf): change testing.T iteration value

### DIFF
--- a/internal/run/test_runner.go
+++ b/internal/run/test_runner.go
@@ -363,7 +363,7 @@ func (r *Run) runWorker(
 			successful := r.activeScenario.Run(
 				metrics.IterationResult,
 				IterationStage,
-				fmt.Sprintf("iteration %d", iteration),
+				strconv.FormatUint(uint64(iteration), 10),
 				scenario.RunFn,
 			)
 			if !successful {


### PR DESCRIPTION
Remove the `"iteration <n>"` prefix and just use `"<n>"` for the iteration field in `T`

It provides no value, as it's obvious from the field name, but leads to extra allocations.

<img width="1916" alt="Screenshot 2024-04-18 at 06 54 12" src="https://github.com/form3tech-oss/f1/assets/82881913/f52be17b-91fe-480d-91b5-bd86e9ab900f">
