### PR TITLE
BREAKING: don't expose internal metrics

### DIFF
--- a/pkg/f1/metrics/metrics.go
+++ b/pkg/f1/metrics/metrics.go
@@ -1,9 +1,0 @@
-package metrics
-
-import (
-	internal_metrics "github.com/form3tech-oss/f1/v2/internal/metrics"
-)
-
-func GetMetrics() *internal_metrics.Metrics {
-	return internal_metrics.Instance()
-}


### PR DESCRIPTION
Don't expose internal metrics.

The internal metrics package is not documented, and interal uses are not isolated in a way where we can make changes without breaking user use cases in subtle ways.

The internal metrics are used for both pushing metrics to prometheus and reporting progress on command execution.

Prefer just to remove the API as it's an easy change for users to notice.

`testing.T.(Time)` is still available and well isolated from internal implementation.

While a breaking change would usually require a major version bump. In this case the user effort of migrating to a v3 would be higher than removing this usage.