### PR TITLE
Revert breaking metrics change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version: '1.22'
       - name: Install gorelease
-        run: go install golang.org/x/exp/cmd/gorelease@v0.0.0-20240103183307-be819d1f06fc
+        run: go install golang.org/x/exp/cmd/gorelease@v0.0.0-20240416160154-fe59bbe5cc7f
       - name: verify-version
         run: echo "Comparing ${{ steps.version.outputs.previous-version }} to ${{ steps.version.outputs.version }}"; gorelease -base ${{ steps.version.outputs.previous-version }} -version ${{ steps.version.outputs.version }}
   Test:

--- a/pkg/f1/metrics/metrics.go
+++ b/pkg/f1/metrics/metrics.go
@@ -1,0 +1,9 @@
+package metrics
+
+import (
+	internal_metrics "github.com/form3tech-oss/f1/v2/internal/metrics"
+)
+
+func GetMetrics() *internal_metrics.Metrics {
+	return internal_metrics.Instance()
+}


### PR DESCRIPTION
While the exported package has its own breaking changes. Prefer to restore it so CI steps don't fail.