### PR TITLE
chore(metrics): simplify metric recording & progress

### DIFF
--- a/internal/run/active_scenario.go
+++ b/internal/run/active_scenario.go
@@ -34,12 +34,12 @@ func NewActiveScenario(scenario *scenarios.Scenario, metricsInstance *metrics.Me
 
 	// wait for completion
 	<-done
-	s.m.Record(metrics.SetupResult, scenario.Name, "setup", metrics.Result(t.Failed()), time.Since(start).Nanoseconds())
+	s.m.RecordSetupResult(scenario.Name, metrics.Result(t.Failed()), time.Since(start).Nanoseconds())
 	return s
 }
 
 // Run performs a single iteration of the test. It returns `true` if the test was successful, `false` otherwise.
-func (s *ActiveScenario) Run(metric metrics.MetricType, stage, iter string, f func(t *testing.T)) bool {
+func (s *ActiveScenario) Run(iter string, f func(t *testing.T)) bool {
 	t, teardown := testing.NewT(iter, s.scenario.Name)
 	defer teardown()
 
@@ -52,10 +52,10 @@ func (s *ActiveScenario) Run(metric metrics.MetricType, stage, iter string, f fu
 
 	// wait for completion
 	<-done
-	s.m.Record(metric, s.scenario.Name, stage, metrics.Result(t.Failed()), time.Since(start).Nanoseconds())
+	s.m.RecordIterationResult(s.scenario.Name, metrics.Result(t.Failed()), time.Since(start).Nanoseconds())
 	return !t.Failed()
 }
 
 func (s *ActiveScenario) RecordDroppedIteration() {
-	s.m.Record(metrics.IterationResult, s.scenario.Name, IterationStage, metrics.DroppedResult, 0)
+	s.m.RecordIterationResult(s.scenario.Name, metrics.DroppedResult, 0)
 }

--- a/internal/run/result.go
+++ b/internal/run/result.go
@@ -35,15 +35,12 @@ type Result struct {
 
 func (r *Result) SetMetrics(
 	result metrics.ResultType,
-	stage string,
 	count uint64,
 	quantiles []*io_prometheus_client.Quantile,
 ) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if stage != IterationStage {
-		return
-	}
+
 	r.RecentDuration = 1 * time.Second
 	switch result {
 	case metrics.SucessResult:
@@ -72,15 +69,11 @@ func (r *Result) ClearProgressMetrics() {
 func (r *Result) IncrementMetrics(
 	duration time.Duration,
 	result metrics.ResultType,
-	stage string,
 	count uint64,
 	quantiles []*io_prometheus_client.Quantile,
 ) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if stage != IterationStage {
-		return
-	}
 	r.RecentDuration = duration
 	switch result {
 	case metrics.SucessResult:

--- a/pkg/f1/testing/t.go
+++ b/pkg/f1/testing/t.go
@@ -166,8 +166,7 @@ func (t *T) teardown() {
 }
 
 func recordTime(t *T, stageName string, start time.Time) {
-	metrics.Instance().Record(
-		metrics.IterationResult,
+	metrics.Instance().RecordIterationStage(
 		t.Scenario,
 		stageName,
 		metrics.Result(t.Failed()),


### PR DESCRIPTION
Changes:
    - Add a few methods to Metrics to be explicit about exactly what is
    recorded.
    - Reduce Progress summary objectives to only percentiles that are
      printed out. No need to record everything if it's not used
    - Remove Progress summary labels that are always constant during a run.