### PR TITLE
fix: don't panic on unknown scenario name

### DIFF
--- a/internal/run/test_runner.go
+++ b/internal/run/test_runner.go
@@ -118,7 +118,11 @@ func (r *Run) Do(ctx context.Context, s *scenarios.Scenarios) (*Result, error) {
 
 	r.metrics.Reset()
 
-	r.activeScenario = NewActiveScenario(s.GetScenario(r.Options.Scenario), r.metrics)
+	scenario := s.GetScenario(r.Options.Scenario)
+	if scenario == nil {
+		return nil, fmt.Errorf("scenario not defined: %s", r.Options.Scenario)
+	}
+	r.activeScenario = NewActiveScenario(scenario, r.metrics)
 	r.pushMetrics(ctx)
 
 	// run teardown even if the context is cancelled

--- a/pkg/f1/f1_stage_test.go
+++ b/pkg/f1/f1_stage_test.go
@@ -83,9 +83,9 @@ func (s *f1Stage) the_f1_scenario_is_executed_with_constant_rate_and_args(args .
 	return s
 }
 
-func (s *f1Stage) an_uknown_f1_scenario_is_executed() *f1Stage {
+func (s *f1Stage) an_unknown_f1_scenario_is_executed() *f1Stage {
 	s.executeErr = s.f1.ExecuteWithArgs([]string{
-		"run", "constant", "uknownScenario",
+		"run", "constant", "unknownScenario",
 	})
 
 	return s

--- a/pkg/f1/f1_stage_test.go
+++ b/pkg/f1/f1_stage_test.go
@@ -24,6 +24,8 @@ type f1Stage struct {
 	errCh    chan error
 	scenario string
 	runCount atomic.Uint32
+
+	executeErr error
 }
 
 func newF1Stage(t *testing.T) (*f1Stage, *f1Stage, *f1Stage) {
@@ -77,6 +79,20 @@ func (s *f1Stage) the_f1_scenario_is_executed_with_constant_rate_and_args(args .
 		"run", "constant", s.scenario,
 	}, args...))
 	s.require.NoError(err, "error executing scenarios")
+
+	return s
+}
+
+func (s *f1Stage) an_uknown_f1_scenario_is_executed() *f1Stage {
+	s.executeErr = s.f1.ExecuteWithArgs([]string{
+		"run", "constant", "uknownScenario",
+	})
+
+	return s
+}
+
+func (s *f1Stage) the_execute_command_returns_an_error(message string) *f1Stage {
+	s.require.ErrorContains(s.executeErr, message)
 
 	return s
 }

--- a/pkg/f1/f1_test.go
+++ b/pkg/f1/f1_test.go
@@ -35,3 +35,13 @@ func TestSignalHandling(t *testing.T) {
 		})
 	}
 }
+
+func TestMissingScenario(t *testing.T) {
+	_, when, then := newF1Stage(t)
+
+	when.
+		an_uknown_f1_scenario_is_executed()
+
+	then.
+		the_execute_command_returns_an_error("scenario not defined: uknownScenario")
+}

--- a/pkg/f1/f1_test.go
+++ b/pkg/f1/f1_test.go
@@ -40,8 +40,8 @@ func TestMissingScenario(t *testing.T) {
 	_, when, then := newF1Stage(t)
 
 	when.
-		an_uknown_f1_scenario_is_executed()
+		an_unknown_f1_scenario_is_executed()
 
 	then.
-		the_execute_command_returns_an_error("scenario not defined: uknownScenario")
+		the_execute_command_returns_an_error("scenario not defined: unknownScenario")
 }


### PR DESCRIPTION
When a scenario that was not added is called via CLI - f1 paniced:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104a8d114]

goroutine 1 [running]:
github.com/form3tech-oss/f1/v2/internal/run.NewActiveScenario(0x0, 0x1400020c5a0)
	/Users/nikolayvladimirov/go/src/github.com/form3tech-oss/f1/internal/run/active_scenario.go:33 +0x24
github.com/form3tech-oss/f1/v2/internal/run.(*Run).Do(0x14000244000, {0x104cb02f0, 0x1400003e280}, 0x14000064020)
	/Users/nikolayvladimirov/go/src/github.com/form3tech-oss/f1/internal/run/test_runner.go:121 +0x1b8
github.com/form3tech-oss/f1/v2/internal/run.Cmd.runCmdExecute.func1(0x1400020ef08, {0x1400003e370, 0x1, 0x5?})
	/Users/nikolayvladimirov/go/src/github.com/form3tech-oss/f1/internal/run/run_cmd.go:158 +0x570
github.com/spf13/cobra.(*Command).execute(0x1400020ef08, {0x1400003e320, 0x5, 0x5})
	/Users/nikolayvladimirov/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x1400020e008)
	/Users/nikolayvladimirov/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/nikolayvladimirov/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/Users/nikolayvladimirov/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1032
github.com/form3tech-oss/f1/v2/pkg/f1.(*F1).execute(0x14000039e50, {0x0, 0x0, 0x0})
	/Users/nikolayvladimirov/go/src/github.com/form3tech-oss/f1/pkg/f1/f1.go:106 +0x16c
github.com/form3tech-oss/f1/v2/pkg/f1.(*F1).Execute(0x14000039e50?)
	/Users/nikolayvladimirov/go/src/github.com/form3tech-oss/f1/pkg/f1/f1.go:123 +0x28
main.main()
	/Users/nikolayvladimirov/go/src/github.com/form3tech-oss/f1/benchcmd/main.go:9 +0x13c
```
<img width="1919" alt="Screenshot 2024-05-02 at 10 44 06" src="https://github.com/form3tech-oss/f1/assets/82881913/3334bd20-e7e1-466e-adc1-1191110e37c2">

