### PR TITLE
Revert "chore(profiling): don't run GC on heap profile"

### DIFF
--- a/pkg/f1/profiling.go
+++ b/pkg/f1/profiling.go
@@ -3,6 +3,7 @@ package f1
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"runtime/pprof"
 )
 
@@ -44,6 +45,8 @@ func (p *profiling) stop() error {
 			return fmt.Errorf("creating memprofile file '%s': %w", p.memProfileFileName, err)
 		}
 		defer f.Close()
+
+		runtime.GC() // get up-to-date statistics
 
 		if err := pprof.WriteHeapProfile(f); err != nil {
 			return fmt.Errorf("writing mem profile: %w", err)


### PR DESCRIPTION
This reverts commit 265762f0509891a68947cdcdbb997be93c7221f1.

Aligns with documentation:
https://pkg.go.dev/runtime/pprof