### PR TITLE
feat: support custom start-time for staged tests

### DIFF
--- a/internal/trigger/file/file_parser.go
+++ b/internal/trigger/file/file_parser.go
@@ -150,6 +150,7 @@ func (s *Stage) parseStage(stageIdx int, defaults Stage) (*runnableStage, error)
 			*validatedStagedStage.IterationFrequency,
 			*validatedStagedStage.Stages,
 			*validatedStagedStage.Distribution,
+			nil,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("calculating staged rate: %w", err)

--- a/internal/trigger/staged/calculator.go
+++ b/internal/trigger/staged/calculator.go
@@ -12,11 +12,14 @@ type rateCalculator struct {
 	start   time.Time
 }
 
-func newRateCalculator(stages []stage) *rateCalculator {
+func newRateCalculator(stages []stage, start *time.Time) *rateCalculator {
 	calculator := rateCalculator{
 		current: -1,
 	}
 	calculator.addRange(stages)
+	if start != nil {
+		calculator.start = *start
+	}
 	return &calculator
 }
 
@@ -39,7 +42,9 @@ func (s *rateCalculator) add(newStage stage) {
 func (s *rateCalculator) Rate(now time.Time) int {
 	if s.current < 0 {
 		s.current = 0
-		s.start = now
+		if s.start.IsZero() {
+			s.start = now
+		}
 	}
 	if s.current > len(s.stages)-1 {
 		return 0

--- a/internal/trigger/staged/calculator.go
+++ b/internal/trigger/staged/calculator.go
@@ -49,7 +49,7 @@ func (s *rateCalculator) Rate(now time.Time) int {
 	if s.current > len(s.stages)-1 {
 		return 0
 	}
-	if now.Sub(s.start)+1 > s.stages[s.current].duration {
+	for s.current < len(s.stages) && now.Sub(s.start)+1 > s.stages[s.current].duration {
 		s.start = s.start.Add(s.stages[s.current].duration)
 		s.current++
 	}
@@ -61,7 +61,7 @@ func (s *rateCalculator) Rate(now time.Time) int {
 	position := float64(offset) / float64(s.stages[s.current].duration)
 	rate := s.stages[s.current].startTarget +
 		int(position*float64(s.stages[s.current].endTarget-s.stages[s.current].startTarget))
-	logrus.Debugf("Stage %d; Triggering %d. Offset: %d, Duration: %d, Position: %v\n",
+	logrus.Infof("Stage %d; Triggering %d. Offset: %d, Duration: %d, Position: %v\n",
 		s.current, rate, offset, s.stages[s.current].duration, position)
 	return rate
 }

--- a/internal/trigger/staged/calculator_test.go
+++ b/internal/trigger/staged/calculator_test.go
@@ -1,0 +1,70 @@
+package staged
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalculatorWithDefaultStartTime(t *testing.T) {
+	t.Parallel()
+
+	calculator := newRateCalculator([]stage{
+		{
+			startTarget: 1,
+			endTarget:   1,
+			duration:    1 * time.Minute,
+		},
+		{
+			startTarget: 10,
+			endTarget:   10,
+			duration:    10 * time.Minute,
+		},
+	}, nil)
+	rate := calculator.Rate(time.Now())
+
+	assert.Equal(t, 0, rate)
+}
+
+func TestCalculatorWithSetStartTime(t *testing.T) {
+	t.Parallel()
+
+	startTime := time.Now().Add(-2 * time.Minute)
+	calculator := newRateCalculator([]stage{
+		{
+			startTarget: 1,
+			endTarget:   10,
+			duration:    1 * time.Minute,
+		},
+		{
+			startTarget: 10,
+			endTarget:   10,
+			duration:    10 * time.Minute,
+		},
+	}, &startTime)
+	rate := calculator.Rate(time.Now())
+
+	assert.Equal(t, 10, rate)
+}
+
+func TestCalculatorWithSetStartTimeOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	startTime := time.Now().Add(-20 * time.Minute)
+	calculator := newRateCalculator([]stage{
+		{
+			startTarget: 1,
+			endTarget:   1,
+			duration:    1 * time.Minute,
+		},
+		{
+			startTarget: 10,
+			endTarget:   10,
+			duration:    10 * time.Minute,
+		},
+	}, &startTime)
+	rate := calculator.Rate(time.Now())
+
+	assert.Equal(t, 0, rate)
+}

--- a/internal/trigger/staged/staged_rate.go
+++ b/internal/trigger/staged/staged_rate.go
@@ -24,6 +24,7 @@ func Rate() api.Builder {
 			"During the stage, the number of concurrent iterations will ramp up or down to the target.")
 	flags.DurationP(flagIterationFrequency, "f", 1*time.Second,
 		"How frequently iterations should be started")
+	flags.String(flagStartTime, "", "Starting point of stage calculation, defaults to now")
 
 	triggerflags.JitterFlag(flags)
 	triggerflags.DistributionFlag(flags)


### PR DESCRIPTION
At the moment we have staged test jobs starting at midnight running for 20 hours, if a job is stopped for some reason, it can't be restarted as we don't want them to overlap.
I would like to specify start time when triggering the job, so that the stage is calculated based on that and not the time that the job was started, this would allow us to run a job every 10 minutes with a duration of 10m, so it self-recovers if a job is killed.