### PR TITLE
feat: don't start a goroutine for each iteration

### DIFF
--- a/benchcmd/main.go
+++ b/benchcmd/main.go
@@ -6,12 +6,23 @@ import (
 )
 
 func main() {
-	f1.New().Add("emptyScenario", emptyScenario).Execute()
+	f1.New().
+		Add("emptyScenario", emptyScenario).
+		Add("failingScenario", failingScenario).
+		Execute()
 }
 
 func emptyScenario(*testing.T) testing.RunFn {
 	runFn := func(t *testing.T) {
 		t.Require().True(true)
+	}
+
+	return runFn
+}
+
+func failingScenario(*testing.T) testing.RunFn {
+	runFn := func(t *testing.T) {
+		t.Require().True(false)
 	}
 
 	return runFn


### PR DESCRIPTION
Handle immediate scenario termination via `panic`/`recover` instead of `Goexit`.


While `Goexit` is more efficient, for iterations that don't fail - it introduces performance overhead as we needed to create a short lived goroutine for each iteration.

### 35% more iterations per second; ~90% less time spent in iterations
<img width="1920" alt="Screenshot 2024-05-17 at 06 49 13" src="https://github.com/form3tech-oss/f1/assets/82881913/04a92e25-1db7-4d66-8921-55ec48d6444d">

### Less allocations to keep the GC busy
<img width="1818" alt="Screenshot 2024-05-17 at 06 52 59" src="https://github.com/form3tech-oss/f1/assets/82881913/9c42f790-73f0-49fd-9d15-a0f848d3cbfa">

### Failing scenario performance is better due to removal of goroutines
<img width="1919" alt="Screenshot 2024-05-17 at 06 57 41" src="https://github.com/form3tech-oss/f1/assets/82881913/69ce234c-e2aa-4726-973a-c71492d7b2bd">


