### PR TITLE
chore: cleanup test output

### DIFF
--- a/internal/chart/chart_cmd_stage_test.go
+++ b/internal/chart/chart_cmd_stage_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/form3tech-oss/f1/v2/internal/console"
@@ -22,6 +23,8 @@ type ChartTestStage struct {
 
 func NewChartTestStage(t *testing.T) (*ChartTestStage, *ChartTestStage, *ChartTestStage) {
 	t.Helper()
+	logrus.SetLevel(logrus.WarnLevel)
+
 	stage := &ChartTestStage{
 		t:      t,
 		assert: assert.New(t),

--- a/internal/run/run_stage_test.go
+++ b/internal/run/run_stage_test.go
@@ -241,7 +241,7 @@ func (s *RunTestStage) the_command_should_have_run_for_approx(expectedDuration t
 }
 
 func (s *RunTestStage) the_number_of_started_iterations_should_be(expected uint32) *RunTestStage {
-	s.assert.Equal(expected, s.runCount.Load(), "number of started iterations")
+	s.assert.Equal(int(expected), int(s.runCount.Load()), "number of started iterations")
 	return s
 }
 

--- a/internal/trigger/file/file_parser_test.go
+++ b/internal/trigger/file/file_parser_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -414,6 +415,7 @@ stages:
 
 func TestFileRate_FileErrors(t *testing.T) {
 	t.Parallel()
+	logrus.SetLevel(logrus.WarnLevel)
 
 	for _, test := range []struct {
 		fileContent, expectedError string

--- a/internal/trigger/file/file_rate.go
+++ b/internal/trigger/file/file_rate.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	"github.com/form3tech-oss/f1/v2/internal/trace"
@@ -79,7 +79,7 @@ func readFile(filename string) (*[]byte, error) {
 	}
 	defer func() {
 		if err = file.Close(); err != nil {
-			log.WithError(err).Error("unable to close the config file")
+			logrus.WithError(err).Error("unable to close the config file")
 		}
 	}()
 

--- a/internal/trigger/gaussian/gaussian_rate.go
+++ b/internal/trigger/gaussian/gaussian_rate.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	"github.com/form3tech-oss/f1/v2/internal/gaussian"
@@ -97,7 +97,7 @@ func Rate() api.Builder {
 			}
 			if peakRate != "" {
 				if volume != defaultVolume {
-					log.Warn("--peak-rate is provided, the value given for --volume will be ignored")
+					logrus.Warn("--peak-rate is provided, the value given for --volume will be ignored")
 				}
 				volume, err = calculateVolume(peakRate, peakDuration, stddevDuration)
 				if err != nil {


### PR DESCRIPTION
Raise log level to warn when running certain tests to avoid poluting the test output.