### PR TITLE
fix(progress): fix rate per second reporting

### DIFF
--- a/internal/run/templates/progress_test.go
+++ b/internal/run/templates/progress_test.go
@@ -35,6 +35,57 @@ func Test_RenderProgress(t *testing.T) {
 			},
 			expected: "[ 1m0s]  ✔    10  ⦸     3  ✘     5 (1/s)   avg: 10µs, min: 1µs, max: 20µs",
 		},
+		{
+			name: "rate rounding",
+			data: templates.ProgressData{
+				Duration:                 1 * time.Minute,
+				SuccessfulIterationCount: 10,
+				DroppedIterationCount:    3,
+				FailedIterationCount:     5,
+				Period:                   980 * time.Millisecond,
+				SuccessfulIterationDurationsForPeriod: progress.IterationDurationsSnapshot{
+					Average: 10 * time.Microsecond,
+					Min:     1 * time.Microsecond,
+					Max:     20 * time.Microsecond,
+					Count:   10,
+				},
+			},
+			expected: "[ 1m0s]  ✔    10  ⦸     3  ✘     5 (10/s)   avg: 10µs, min: 1µs, max: 20µs",
+		},
+		{
+			name: "period less than 500ms",
+			data: templates.ProgressData{
+				Duration:                 1 * time.Minute,
+				SuccessfulIterationCount: 10,
+				DroppedIterationCount:    3,
+				FailedIterationCount:     5,
+				Period:                   100 * time.Millisecond,
+				SuccessfulIterationDurationsForPeriod: progress.IterationDurationsSnapshot{
+					Average: 10 * time.Microsecond,
+					Min:     1 * time.Microsecond,
+					Max:     20 * time.Microsecond,
+					Count:   10,
+				},
+			},
+			expected: "[ 1m0s]  ✔    10  ⦸     3  ✘     5 (0/s)   avg: 10µs, min: 1µs, max: 20µs",
+		},
+		{
+			name: "no iterations",
+			data: templates.ProgressData{
+				Duration:                 1 * time.Minute,
+				SuccessfulIterationCount: 0,
+				DroppedIterationCount:    0,
+				FailedIterationCount:     0,
+				Period:                   1 * time.Second,
+				SuccessfulIterationDurationsForPeriod: progress.IterationDurationsSnapshot{
+					Average: 0,
+					Min:     0,
+					Max:     0,
+					Count:   0,
+				},
+			},
+			expected: "[ 1m0s]  ✔     0  ✘     0 (0/s)   avg: 0s, min: 0s, max: 0s",
+		},
 	}
 
 	tmpl := templates.Parse(templates.DisableRenderTermColors)

--- a/internal/run/templates/templates.go
+++ b/internal/run/templates/templates.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"math"
 	"strings"
 	"text/template"
 	"time"
@@ -29,10 +30,13 @@ type Templates struct {
 func Parse(renderTermColors RenderTermColorsType) *Templates {
 	templateFunctions := template.FuncMap{
 		"rate": func(duration time.Duration, count uint64) uint64 {
-			if uint64(duration/time.Second) == 0 {
+			durationInSeconds := duration.Round(time.Second).Seconds()
+
+			if durationInSeconds == 0 {
 				return 0
 			}
-			return count / uint64(duration/time.Second)
+
+			return uint64(math.Round(float64(count) / durationInSeconds))
 		},
 		"durationSeconds": func(d time.Duration) time.Duration {
 			return d.Round(time.Second)


### PR DESCRIPTION
Use rounding functions to get a better iterations per second number.

Previously if the rate calculation always truncated to the closest second. Meaning, for 10 iterations in 980ms it reported 0 iterations per second. This change correctly reports a rate of 10/s.

<img width="1913" alt="Screenshot 2024-06-04 at 08 41 11" src="https://github.com/form3tech-oss/f1/assets/82881913/377405f0-f4dc-46a9-be5a-5c90e64a2f38">
