### PR TITLE
feat: rewrite work scheduling to improve performance

### DIFF
--- a/benchcmd/main.go
+++ b/benchcmd/main.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"os"
+	"strconv"
+	"time"
+
 	"github.com/form3tech-oss/f1/v2/pkg/f1"
 	"github.com/form3tech-oss/f1/v2/pkg/f1/testing"
 )
@@ -9,12 +13,25 @@ func main() {
 	f1.New().
 		Add("emptyScenario", emptyScenario).
 		Add("failingScenario", failingScenario).
+		Add("sleepScenario", sleepScenario).
 		Execute()
 }
 
 func emptyScenario(*testing.T) testing.RunFn {
 	runFn := func(t *testing.T) {
 		t.Require().True(true)
+	}
+
+	return runFn
+}
+
+func sleepScenario(t *testing.T) testing.RunFn {
+	msString := os.Getenv("MS_SLEEP")
+	ms, err := strconv.ParseInt(msString, 10, 64)
+	t.Require().NoError(err)
+
+	runFn := func(*testing.T) {
+		time.Sleep(time.Duration(ms) * time.Millisecond)
 	}
 
 	return runFn

--- a/internal/progress/average.go
+++ b/internal/progress/average.go
@@ -95,8 +95,8 @@ type DurationStats struct {
 	lifetime IterationDurations
 }
 
-func (d *DurationStats) Record(duration time.Duration) {
-	d.running.Add(duration.Abs().Nanoseconds())
+func (d *DurationStats) Record(nanoseconds int64) {
+	d.running.Add(nanoseconds)
 }
 
 func (d *DurationStats) CollectLifetime() (IterationDurationsSnapshot, IterationDurationsSnapshot) {

--- a/internal/progress/stats.go
+++ b/internal/progress/stats.go
@@ -14,12 +14,12 @@ type Stats struct {
 	droppedIterationCount atomic.Uint64
 }
 
-func (s *Stats) Record(result metrics.ResultType, duration time.Duration) {
+func (s *Stats) Record(result metrics.ResultType, nanoseconds int64) {
 	switch result {
 	case metrics.SucessResult:
-		s.successfulIterationDurations.Record(duration)
+		s.successfulIterationDurations.Record(nanoseconds)
 	case metrics.FailedResult:
-		s.failedIterationDurations.Record(duration)
+		s.failedIterationDurations.Record(nanoseconds)
 	case metrics.DroppedResult:
 		s.droppedIterationCount.Add(1)
 	case metrics.UnknownResult:

--- a/internal/run/test_runner.go
+++ b/internal/run/test_runner.go
@@ -236,7 +236,7 @@ func (r *Run) run(ctx context.Context) {
 	triggerCtx, triggerCancel := context.WithTimeout(ctx, duration-nextIterationWindow)
 	defer triggerCancel()
 
-	poolManager := workers.New(r.Options.MaxIterations, r.activeScenario, r.tracer)
+	poolManager := workers.New(r.Options.MaxIterations, r.activeScenario)
 	r.trigger.Trigger(triggerCtx, poolManager, r.Options)
 
 	select {

--- a/internal/trigger/api/iteration_worker.go
+++ b/internal/trigger/api/iteration_worker.go
@@ -14,10 +14,10 @@ func NewIterationWorker(iterationDuration time.Duration, rate RateFunction, trac
 	return func(ctx context.Context, workers *workers.PoolManager, opts options.RunOptions) {
 		startRate := rate(time.Now())
 
-		pool := workers.NewPool(opts.Concurrency)
+		pool := workers.NewTriggerPool(opts.Concurrency)
 		workerCtx := pool.Start(ctx)
 
-		pool.QueueOrDrop(workerCtx, startRate)
+		pool.Trigger(workerCtx, startRate)
 
 		// start ticker to trigger subsequent iterations.
 		iterationTicker := time.NewTicker(iterationDuration)
@@ -31,7 +31,7 @@ func NewIterationWorker(iterationDuration time.Duration, rate RateFunction, trac
 				return
 			case start := <-iterationTicker.C:
 				iterationRate := rate(start)
-				pool.QueueOrDrop(workerCtx, iterationRate)
+				pool.Trigger(workerCtx, iterationRate)
 			}
 		}
 	}

--- a/internal/trigger/users/users_rate.go
+++ b/internal/trigger/users/users_rate.go
@@ -41,10 +41,7 @@ func Rate() api.Builder {
 
 func NewWorker(concurrency int) api.WorkTriggerer {
 	return func(ctx context.Context, workers *workers.PoolManager, _ options.RunOptions) {
-		pool := workers.NewPool(concurrency)
-		workerCtx := pool.Start(ctx)
-
-		for pool.Queue(workerCtx) {
-		}
+		pool := workers.NewContinuousPool(concurrency)
+		pool.Start(ctx)
 	}
 }

--- a/internal/workers/continuous_pool.go
+++ b/internal/workers/continuous_pool.go
@@ -1,0 +1,79 @@
+package workers
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+)
+
+func newContinuousPool(m *PoolManager, numWorkers int) *ContinuousPool {
+	p := &ContinuousPool{
+		numWorkers:         numWorkers,
+		iterationStatePool: make([]*iterationState, numWorkers),
+		manager:            m,
+	}
+
+	for i := range numWorkers {
+		p.iterationStatePool[i] = newIterationState(m.activeScenario.scenario.Name)
+	}
+
+	return p
+}
+
+type ContinuousPool struct {
+	manager            *PoolManager
+	workerCtxCancel    context.CancelFunc
+	iterationStatePool []*iterationState
+	numWorkers         int
+	stopWorkers        atomic.Bool
+}
+
+func (p *ContinuousPool) Start(ctx context.Context) {
+	workerCtx, workerCtxCancel := context.WithCancel(ctx)
+	p.workerCtxCancel = workerCtxCancel
+
+	workersStarted := sync.WaitGroup{}
+
+	workersStarted.Add(p.numWorkers)
+	p.manager.runningWorkers.Add(p.numWorkers)
+	for _, iterationState := range p.iterationStatePool {
+		go p.startWorker(iterationState, &workersStarted)
+	}
+
+	// context.Done() and context.Err() for context that can be cancelled use a Lock.
+	// To avoid frequent locking - use an atomic.Bool for cancellation instead of checking the
+	// context on each iteration
+	go func() {
+		<-workerCtx.Done()
+		p.stopWorkers.Store(true)
+	}()
+}
+
+func (p *ContinuousPool) maxIterationsReached() {
+	p.workerCtxCancel()
+}
+
+func (p *ContinuousPool) startWorker(
+	iterationState *iterationState,
+	workersStarted *sync.WaitGroup,
+) {
+	defer p.manager.runningWorkers.Done()
+
+	// wait for all workers to start before execution to make sure we're executing at the
+	// concurrency requested
+	workersStarted.Done()
+	workersStarted.Wait()
+
+	// use and atomic.Bool to control execution to avoid mutex usage in channels and context.Context
+	for !p.stopWorkers.Load() {
+		iteration, err := p.manager.NextIteration()
+		if err != nil {
+			p.maxIterationsReached()
+			return
+		}
+
+		iterationState.t.Reset(strconv.FormatUint(iteration, 10))
+		p.manager.activeScenario.Run(iterationState)
+	}
+}

--- a/internal/workers/queue_pool.go
+++ b/internal/workers/queue_pool.go
@@ -1,0 +1,149 @@
+package workers
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+)
+
+func newTriggerPool(m *PoolManager, numWorkers int) *TriggerPool {
+	p := &TriggerPool{
+		numWorkers:         numWorkers,
+		iterationStatePool: make([]*iterationState, numWorkers),
+		manager:            m,
+		jobsAvailableCond:  sync.NewCond(&sync.Mutex{}),
+	}
+
+	for i := range numWorkers {
+		p.iterationStatePool[i] = newIterationState(m.activeScenario.scenario.Name)
+	}
+
+	return p
+}
+
+type TriggerPool struct {
+	manager         *PoolManager
+	workerCtxCancel context.CancelFunc
+	// jobsAvailableCond will notify blocked workers to start executing work again
+	jobsAvailableCond  *sync.Cond
+	iterationStatePool []*iterationState
+	numWorkers         int
+	// jobsToExecute holds a number of pending work to execute
+	jobsToExecute jobCounter
+	stopWorkers   atomic.Bool
+}
+
+// Trigger will trigger the execution of a numJobs in the worker pool,
+// discarding anything that is currently scheduled for execution.
+func (p *TriggerPool) Trigger(ctx context.Context, numJobs int) {
+	if ctx.Err() != nil {
+		return
+	}
+	p.sendJobsForExecution(numJobs)
+}
+
+func (p *TriggerPool) Start(ctx context.Context) context.Context {
+	p.manager.runningWorkers.Add(p.numWorkers)
+
+	startedWg := sync.WaitGroup{}
+	startedWg.Add(p.numWorkers)
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	p.workerCtxCancel = cancel
+
+	for _, statePool := range p.iterationStatePool {
+		go p.run(statePool, &startedWg)
+	}
+
+	// wait for all workers to start, to make sure we have the concurrency requested,
+	// and work is not dropped
+	startedWg.Wait()
+
+	// context.Done() and context.Err() for context that can be cancelled use a Lock.
+	// To avoid frequent locking - use an atomic.Bool for cancellation instead of checking the
+	// context on each iteration
+	go func() {
+		<-workerCtx.Done()
+		p.stop()
+	}()
+
+	return workerCtx
+}
+
+func (p *TriggerPool) running() bool {
+	return !p.stopWorkers.Load()
+}
+
+func (p *TriggerPool) stop() {
+	p.stopWorkers.Store(true)
+	p.sendJobsForExecution(0)
+}
+
+func (p *TriggerPool) maxIterationsReached() {
+	p.jobsToExecute.set(0)
+	p.workerCtxCancel()
+}
+
+func (p *TriggerPool) sendJobsForExecution(numJobs int) {
+	p.jobsAvailableCond.L.Lock()
+
+	jobsDiscarded := p.jobsToExecute.set(numJobs)
+	p.jobsAvailableCond.Broadcast()
+
+	p.jobsAvailableCond.L.Unlock()
+
+	for range jobsDiscarded {
+		p.manager.activeScenario.RecordDroppedIteration()
+	}
+}
+
+func (p *TriggerPool) waitForNewJobs() {
+	p.jobsAvailableCond.L.Lock()
+
+	for p.jobsToExecute.none() && p.running() {
+		p.jobsAvailableCond.Wait()
+	}
+	p.jobsAvailableCond.L.Unlock()
+}
+
+func (p *TriggerPool) run(
+	iterationState *iterationState,
+	startWg *sync.WaitGroup,
+) {
+	defer p.manager.runningWorkers.Done()
+	startWg.Done()
+
+	for p.running() {
+		if p.jobsToExecute.none() {
+			p.waitForNewJobs()
+		}
+
+		if p.jobsToExecute.take() {
+			iteration, err := p.manager.NextIteration()
+			if err != nil {
+				p.maxIterationsReached()
+				return
+			}
+
+			iterationState.t.Reset(strconv.FormatUint(iteration, 10))
+			p.manager.activeScenario.Run(iterationState)
+		}
+	}
+}
+
+type jobCounter struct {
+	num atomic.Int64
+}
+
+func (w *jobCounter) set(n int) int64 {
+	return w.num.Swap(int64(n))
+}
+
+func (w *jobCounter) none() bool {
+	return w.num.Load() <= 0
+}
+
+func (w *jobCounter) take() bool {
+	return w.num.Add(-1) >= 0
+}

--- a/internal/workers/workers.go
+++ b/internal/workers/workers.go
@@ -1,12 +1,10 @@
 package workers
 
 import (
-	"context"
-	"strconv"
+	"errors"
 	"sync"
 	"sync/atomic"
 
-	"github.com/form3tech-oss/f1/v2/internal/trace"
 	"github.com/form3tech-oss/f1/v2/pkg/f1/testing"
 )
 
@@ -23,17 +21,15 @@ func newIterationState(scenario string) *iterationState {
 }
 
 type PoolManager struct {
-	tracer         trace.Tracer
 	activeScenario *ActiveScenario
 	iteration      atomic.Uint64
 	maxIterations  uint64
 	runningWorkers sync.WaitGroup
 }
 
-func New(maxIterations uint64, activeScenario *ActiveScenario, tracer trace.Tracer) *PoolManager {
+func New(maxIterations uint64, activeScenario *ActiveScenario) *PoolManager {
 	w := &PoolManager{
 		activeScenario: activeScenario,
-		tracer:         tracer,
 		maxIterations:  maxIterations,
 	}
 
@@ -57,105 +53,21 @@ func (m *PoolManager) MaxIterationsReached() bool {
 	return false
 }
 
-type Pool struct {
-	workQueue          chan struct{}
-	manager            *PoolManager
-	workerCtxCancel    context.CancelFunc
-	iterationStatePool []*iterationState
-	totalWorkers       int
-	busyWorkers        atomic.Int32
+var errMaxIterationsReached = errors.New("max iterations reached")
+
+func (m *PoolManager) NextIteration() (uint64, error) {
+	iteration := m.iteration.Add(1)
+	if m.maxIterations > 0 && iteration > m.maxIterations {
+		return 0, errMaxIterationsReached
+	}
+
+	return iteration, nil
 }
 
-func (m *PoolManager) NewPool(totalWorkers int) *Pool {
-	p := &Pool{
-		totalWorkers:       totalWorkers,
-		iterationStatePool: make([]*iterationState, totalWorkers),
-		workQueue:          make(chan struct{}, totalWorkers),
-		manager:            m,
-	}
-
-	for i := range totalWorkers {
-		p.iterationStatePool[i] = newIterationState(m.activeScenario.scenario.Name)
-	}
-
-	return p
+func (m *PoolManager) NewTriggerPool(numWorkers int) *TriggerPool {
+	return newTriggerPool(m, numWorkers)
 }
 
-func (p *Pool) QueueOrDrop(ctx context.Context, triggersCount int) {
-	for range triggersCount {
-		if p.busyWorkers.Load() >= int32(p.totalWorkers) {
-			p.manager.activeScenario.RecordDroppedIteration()
-			continue
-		}
-
-		select {
-		case <-ctx.Done():
-			return
-		case p.workQueue <- struct{}{}:
-		}
-	}
-}
-
-func (p *Pool) Queue(ctx context.Context) bool {
-	select {
-	case <-ctx.Done():
-		return false
-	case p.workQueue <- struct{}{}:
-		return true
-	}
-}
-
-func (p *Pool) Start(ctx context.Context) context.Context {
-	p.manager.runningWorkers.Add(p.totalWorkers)
-
-	startedWg := sync.WaitGroup{}
-	startedWg.Add(p.totalWorkers)
-
-	workerCtx, cancel := context.WithCancel(ctx)
-	p.workerCtxCancel = cancel
-
-	for i := range p.totalWorkers {
-		go p.run(workerCtx, i, p.iterationStatePool[i], &startedWg)
-	}
-	startedWg.Wait()
-
-	return workerCtx
-}
-
-func (p *Pool) run(
-	ctx context.Context,
-	worker int,
-	iterationState *iterationState,
-	startWg *sync.WaitGroup,
-) {
-	defer p.manager.runningWorkers.Done()
-
-	p.manager.tracer.WorkerEvent("Started worker", worker)
-	startWg.Done()
-	for {
-		select {
-		case <-ctx.Done():
-			p.manager.tracer.WorkerEvent("Stopping worker", worker)
-			return
-		case <-p.workQueue:
-			if ctx.Err() != nil {
-				return
-			}
-
-			iteration := p.manager.iteration.Add(1)
-			if p.manager.maxIterations > 0 && iteration > p.manager.maxIterations {
-				p.workerCtxCancel()
-				return
-			}
-			p.manager.tracer.IterationEvent("Received work from Channel 'doWork'", iteration)
-
-			iterationState.t.Reset(strconv.FormatUint(iteration, 10))
-
-			p.busyWorkers.Add(1)
-			p.manager.activeScenario.Run(iterationState)
-			p.busyWorkers.Add(-1)
-
-			p.manager.tracer.IterationEvent("Completed iteration", iteration)
-		}
-	}
+func (m *PoolManager) NewContinuousPool(numWorkers int) *ContinuousPool {
+	return newContinuousPool(m, numWorkers)
 }

--- a/internal/xtime/nanotime.go
+++ b/internal/xtime/nanotime.go
@@ -1,0 +1,24 @@
+package xtime
+
+import "unsafe"
+
+// Make goimports import the unsafe package, which is required to be able
+// to use //go:linkname
+var _ = unsafe.Sizeof(0)
+
+//go:noescape
+//go:linkname nanotime runtime.nanotime
+func nanotime() int64
+
+// NanoTime returns the current time in nanoseconds from a monotonic clock.
+// The time returned is based on some arbitrary platform-specific point in the
+// past. The time returned is guaranteed to increase monotonically at a
+// constant rate
+//
+// This can be use for performance critical code where getting the wall time
+// can slow down execution.
+//
+// https://github.com/golang/go/issues/12914
+func NanoTime() int64 {
+	return nanotime()
+}

--- a/internal/xtime/nanotime_test.go
+++ b/internal/xtime/nanotime_test.go
@@ -1,0 +1,19 @@
+package xtime_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/form3tech-oss/f1/v2/internal/xtime"
+)
+
+func TestNanoTime(t *testing.T) {
+	t.Parallel()
+
+	for range 100 {
+		t1 := xtime.NanoTime()
+		t2 := xtime.NanoTime()
+		assert.LessOrEqual(t, t1, t2, "monotonic clock should always increase")
+	}
+}


### PR DESCRIPTION
# Description

Rewrite worker pools to avoid internal lock usage in channels and context.Context.

Any time a lock is used it will drastically slow down execution as:
 - needs to do a syscall to sleep, leading to a context switch out of user space
 - the go scheduler will interrupt the current go routine and try to find a new one that can execute, leading to a massive overhead in the go scheduler. 

# Changes
 - **Change in behaviour**: previously the iteration trigger (constant, staged rate) would drop iterations if all workers are busy at time of trigger. Currently it will drop iterations not executed since the last trigger. Meaning the workers will try to execute as many iterations as they can before the next trigger and then drop, instead of dropping at time of trigger:
 
<img width="1917" alt="Screenshot 2024-06-07 at 07 39 59" src="https://github.com/form3tech-oss/f1/assets/82881913/f4b68a1d-85e2-466b-b031-e12f6df643e1">

  
 - Separate worker pool implementation for users and iteration triggers
 - Don't use wall clock to measure iteration duration
 - Don't use channels to trigger work to avoid locking
 - remove `tracer` from the worker pool as it provides little value.
 - Add a scenario that sleeps a configurable duration to the benchmark command.
 
`ContinuousPool`:

The `users` trigger type executes the scenario as fasts as possible given a number of workers. Meaning, we don't need a channel to trigger or control the work externally. Just start a for loop to run jobs until timeout has passed or max iterations have been reached.

`TriggerPool`:

The `iterations` trigger will try to execute a certain number of jobs on a specific time interval(for example 10 per 100ms). Instead of using a channel to send individual jobs to the pool, just set an atomic number and run the worker pool until that number reaches 0 (all jobs are executed) 

# Benchmarks

## Users - low concurrency

 - x7 faster
 - drastically reduced system time
 - drastically reduced Involuntary context switches. 
 - Removes most of the system time, by avoiding locks what need a syscall to sleep. 

<img width="1915" alt="Screenshot 2024-06-07 at 06 31 20" src="https://github.com/form3tech-oss/f1/assets/82881913/7855b306-eafa-4ebe-a2ce-0267d2e5ab0e">

### CPU Profile

#### Before
![low_concurrency_master](https://github.com/form3tech-oss/f1/assets/82881913/6e6fefc7-1f53-472d-9c10-7986a737c944)

#### After
![low_concurrency_new](https://github.com/form3tech-oss/f1/assets/82881913/68cdd605-ad2e-4db2-89a4-f2bb52bd55e3)

## Users - high concurrency

- x6 faster

<img width="1917" alt="Screenshot 2024-06-07 at 06 38 49" src="https://github.com/form3tech-oss/f1/assets/82881913/b18abe38-2966-4ae1-8e40-8bdc11f9479f">


## Constant - high concurrency

- Less time spent in scheduler, leads to less dropped iterations.

<img width="1917" alt="Screenshot 2024-06-07 at 07 24 05" src="https://github.com/form3tech-oss/f1/assets/82881913/ae4eb532-ab99-4fc7-9c12-6e581de14cd6">


