### PR TITLE
feat: deprecate GetMetrics()

### DIFF
--- a/pkg/f1/metrics/metrics.go
+++ b/pkg/f1/metrics/metrics.go
@@ -4,6 +4,7 @@ import (
 	internal_metrics "github.com/form3tech-oss/f1/v2/internal/metrics"
 )
 
+// Deprecated: internal metrics will not be exposed in future versions
 func GetMetrics() *internal_metrics.Metrics {
 	return internal_metrics.Instance()
 }


### PR DESCRIPTION
This exposes internal metrics that should not be accessed.

Ideally we want the flexibility to change them at will without breaking the API.