### PR TITLE
fix: exit after a timeout on stuck iterations

### DIFF
--- a/internal/run/run_cmd.go
+++ b/internal/run/run_cmd.go
@@ -16,6 +16,8 @@ import (
 	"github.com/form3tech-oss/f1/v2/pkg/f1/scenarios"
 )
 
+const waitForCompletionTimeout = 10 * time.Second
+
 func Cmd(
 	s *scenarios.Scenarios,
 	builders []api.Builder,
@@ -157,7 +159,7 @@ func runCmdExecute(
 			MaxFailures:     maxFailures,
 			MaxFailuresRate: maxFailuresRate,
 			IgnoreDropped:   ignoreDropped,
-		}, s, trig, settings, metricsInstance, output)
+		}, s, trig, waitForCompletionTimeout, settings, metricsInstance, output)
 		if err != nil {
 			return fmt.Errorf("new run: %w", err)
 		}

--- a/internal/ui/printer.go
+++ b/internal/ui/printer.go
@@ -34,14 +34,6 @@ func (t *Printer) Error(a ...any) {
 	fmt.Fprintln(t.ErrWriter, a...)
 }
 
-func (t *Printer) Printf(format string, a ...any) {
-	fmt.Fprintf(t.Writer, format, a...)
-}
-
 func (t *Printer) Warn(a ...any) {
-	fmt.Fprint(t.ErrWriter, a...)
-}
-
-func (t *Printer) Warnf(format string, a ...any) {
-	fmt.Fprintf(t.ErrWriter, format, a...)
+	fmt.Fprintln(t.ErrWriter, a...)
 }


### PR DESCRIPTION
In case an interation is stuck for whatever reason f1 will never exit.

This adds a 10s timeout to wait for active iterations to complete.