### PR TITLE
feat: support user provided loggers

### DIFF
--- a/internal/ui/output.go
+++ b/internal/ui/output.go
@@ -58,3 +58,10 @@ func NewDefaultOutput(logLevel slog.Level, jsonFormat bool) *Output {
 
 	return NewOutput(logger, printer, interactive, true)
 }
+
+func NewDefaultOutputWithLogger(logger *slog.Logger) *Output {
+	printer := NewDefaultPrinter()
+	interactive := isatty.IsTerminal(os.Stdin.Fd())
+
+	return NewOutput(logger, printer, interactive, true)
+}

--- a/pkg/f1/f1.go
+++ b/pkg/f1/f1.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -32,7 +33,7 @@ type F1 struct {
 	settings  envsettings.Settings
 }
 
-// Instantiates a new instance of an F1 CLI.
+// New instantiates a new instance of an F1 CLI.
 func New() *F1 {
 	settings := envsettings.Get()
 
@@ -42,6 +43,17 @@ func New() *F1 {
 		settings:  settings,
 		output:    ui.NewDefaultOutput(settings.Log.SlogLevel(), settings.Log.IsFormatJSON()),
 	}
+}
+
+// WithLogger allows specifying logger to be used for all internal and scenario logs
+//
+// This will disable the LOG_LEVEL and LOG_FORMAT options, as they only relate to the built-in
+// logger.
+//
+// The logger will be used for non-interactive output, file logs or when `--verbose` is specified.
+func (f *F1) WithLogger(logger *slog.Logger) *F1 {
+	f.output = ui.NewDefaultOutputWithLogger(logger)
+	return f
 }
 
 // Registers a new test scenario with the given name. This is the name used when running

--- a/pkg/f1/f1_test.go
+++ b/pkg/f1/f1_test.go
@@ -45,3 +45,20 @@ func TestMissingScenario(t *testing.T) {
 	then.
 		the_execute_command_returns_an_error("scenario not defined: unknownScenario")
 }
+
+func TestWithCustomLogger(t *testing.T) {
+	given, when, then := newF1Stage(t)
+
+	given.
+		a_custom_logger_is_configured_with_attr("custom", "value").and().
+		a_scenario_that_logs()
+
+	when.
+		the_f1_scenario_is_executed_with_constant_rate_and_args(
+			"--rate", "1/1s",
+			"--max-duration", "2s",
+		)
+
+	then.
+		expect_all_log_lines_to_contain_attr("custom", "value")
+}


### PR DESCRIPTION
The built in logger, especially the JSON formater is very opinionated about the syntax and the fields to align with logrus behavior within the Form3 domain (such as `@timestamp` field name and the time formatting for it, etc.)

While we want to keep the defaults for ease of use, allow users to specify their own logger to align with their organizational ecosystem. 