### PR TITLE
fix: users in a staged run would exit immediately without max iterations

### DIFF
--- a/internal/run/run_cmd_test.go
+++ b/internal/run/run_cmd_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const Any = int64(-1)
+
 func TestSimpleFlow(t *testing.T) {
 	t.Parallel()
 
@@ -49,7 +51,7 @@ type testParam struct {
 	constantRate              string
 	testDuration              time.Duration
 	expectedRunTime           time.Duration
-	expectedCompletedTests    uint32
+	expectedCompletedTests    int64
 	concurrency               int
 	iterationDuration         time.Duration
 	expectedDroppedIterations uint64
@@ -348,6 +350,15 @@ func TestParameterised(t *testing.T) {
 			iterationDuration:      150 * time.Millisecond,
 			expectedRunTime:        1800 * time.Millisecond,
 			expectedCompletedTests: 105,
+		},
+		{
+			name:                   "staged users without max iterations",
+			triggerType:            File,
+			configFile:             "../testdata/config-file-issue-268.yaml",
+			testDuration:           5 * time.Second,
+			iterationDuration:      0,
+			expectedRunTime:        3000 * time.Millisecond,
+			expectedCompletedTests: Any,
 		},
 		{
 			name:                   "config file test using limited max-duration",

--- a/internal/run/run_stage_test.go
+++ b/internal/run/run_stage_test.go
@@ -261,8 +261,12 @@ func (s *RunTestStage) the_command_should_have_run_for_approx(expectedDuration t
 	return s
 }
 
-func (s *RunTestStage) the_number_of_started_iterations_should_be(expected uint32) *RunTestStage {
-	s.assert.Equal(int(expected), int(s.runCount.Load()), "number of started iterations")
+func (s *RunTestStage) the_number_of_started_iterations_should_be(expected int64) *RunTestStage {
+	if expected == Any {
+		s.assert.Positive(s.runCount.Load())
+	} else {
+		s.assert.Equal(int(expected), int(s.runCount.Load()), "number of started iterations")
+	}
 	return s
 }
 
@@ -355,8 +359,12 @@ func (s *RunTestStage) setup_teardown_is_called() *RunTestStage {
 	return s
 }
 
-func (s *RunTestStage) iteration_teardown_is_called_n_times(n uint32) *RunTestStage {
-	s.assert.Equal(int(n), int(s.iterationTeardownCount.Load()), "iteration teardown was not called expected times")
+func (s *RunTestStage) iteration_teardown_is_called_n_times(n int64) *RunTestStage {
+	if n == Any {
+		s.assert.Positive(s.iterationTeardownCount.Load())
+	} else {
+		s.assert.Equal(int(n), int(s.iterationTeardownCount.Load()), "iteration teardown was not called expected times")
+	}
 	return s
 }
 

--- a/internal/testdata/config-file-issue-268.yaml
+++ b/internal/testdata/config-file-issue-268.yaml
@@ -1,0 +1,9 @@
+scenario: test
+limits:
+  max-duration: 5s
+  max-iterations: 0
+  concurrency: 5
+  ignore-dropped: true
+stages:
+  - duration: 3s
+    mode: users

--- a/internal/trigger/users/users_rate.go
+++ b/internal/trigger/users/users_rate.go
@@ -48,5 +48,6 @@ func NewWorker(concurrency int) api.WorkTriggerer {
 	return func(ctx context.Context, _ *ui.Output, workers *workers.PoolManager, _ options.RunOptions) {
 		pool := workers.NewContinuousPool(concurrency)
 		pool.Start(ctx)
+		<-workers.WaitForCompletion()
 	}
 }


### PR DESCRIPTION
Fixes #268

When a stage with `users` mode is run:
1. Starts a go routine with the worker
2. That go routine exits immediately as it only starts the pool.
3. It will then cancel the pool context and the test will immediately exit, ignoring max duration for the test

To avoid this wait for the pool to complete (reaching context timeout on the duration or max iterations) as part of the pool executor itself.

This is not a problem when `users` is run outside of a staged run as the top level runner will always wait for completion before cancelling the worker context.
<img width="1918" alt="Screenshot 2024-08-27 at 08 03 23" src="https://github.com/user-attachments/assets/af090e10-3002-453a-a658-56cdc54e9648">

