### PR TITLE
chore(ci): allow tests to run on Pull Requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,8 @@
-on: [push]
+on:
+  push:
+    branches: [ "master"]
+  pull_request:
+    branches: [ "master"]
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Currently pull requests from forks don't trigger the test suite.

This allows the test suite to run on pull requests from forks after manual approval by a codeowner.