### PR TITLE
fix: Add F1_ prefix to over-scoped LOG_LEVEL, LOG_FORMAT environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ It provides the following information:
 | `PROMETHEUS_NAMESPACE` | string | `""` | Sets the metric label `namespace` to the specified value. Label is omitted if the value provided is empty.|
 | `PROMETHEUS_LABEL_ID` | string | `""` | Sets the metric label `id` to the specified value. Label is omitted if the value provided is empty.|
 | `LOG_FILE_PATH` | string | `""`| Specify the log file path used if `--verbose` is disabled. The logfile path will be an automatically generated temp file if not specified. |
-| `LOG_LEVEL` | string | `"info"`| Specify the log level of the default logger, one of: `debug`, `warn`, `error`  |
-| `LOG_FORMAT` | string | `""`| Specify the log format of the default logger, defaults to `text` formatter, allows `json`  |
+| `F1_LOG_LEVEL` | string | `"info"`| Specify the log level of the default logger, one of: `debug`, `warn`, `error`  |
+| `F1_LOG_FORMAT` | string | `""`| Specify the log format of the default logger, defaults to `text` formatter, allows `json`  |
 
 ## Contributions
 If you'd like to help improve `f1`, please fork this repo and raise a PR!

--- a/internal/envsettings/env.go
+++ b/internal/envsettings/env.go
@@ -12,8 +12,8 @@ const (
 	EnvPrometheusPushGateway = "PROMETHEUS_PUSH_GATEWAY"
 
 	EnvLogFilePath = "LOG_FILE_PATH"
-	EnvLogFormat   = "LOG_FORMAT"
-	EnvLogLevel    = "LOG_LEVEL"
+	EnvLogFormat   = "F1_LOG_FORMAT"
+	EnvLogLevel    = "F1_LOG_LEVEL"
 
 	EnvFluentdHost = "FLUENTD_HOST"
 	EnvFluentdPort = "FLUENTD_PORT"

--- a/pkg/f1/f1.go
+++ b/pkg/f1/f1.go
@@ -47,7 +47,7 @@ func New() *F1 {
 
 // WithLogger allows specifying logger to be used for all internal and scenario logs
 //
-// This will disable the LOG_LEVEL and LOG_FORMAT options, as they only relate to the built-in
+// This will disable the F1_LOG_LEVEL and F1_LOG_FORMAT options, as they only relate to the built-in
 // logger.
 //
 // The logger will be used for non-interactive output, file logs or when `--verbose` is specified.


### PR DESCRIPTION
The change is needed for back-compatibility with previous versions when `LOG_LEVEL` and `LOG_FORMAT` were not used to control f1 outputs (introduced here https://github.com/form3tech-oss/f1/pull/260)

As these are quite common env variable names, they are currently over-scoped. F1 users might want to use custom loggers within their own scenarios that rely on such environment variables and configure them differently than f1 runner itself.

`LOG_FILE_PATH` variable stays the same for back-compatibility as it was present for a long time.