### PR TITLE
Assign VUIDs on iterationState pool creation

### DIFF
--- a/internal/workers/active_scenario.go
+++ b/internal/workers/active_scenario.go
@@ -63,8 +63,9 @@ func (s *ActiveScenario) Setup() {
 	s.m.RecordSetupResult(s.scenario.Name, metrics.Result(s.t.Failed()), duration)
 }
 
-func (s *ActiveScenario) newIterationState() *iterationState {
+func (s *ActiveScenario) newIterationState(id int) *iterationState {
 	t, teardown := testing.NewTWithOptions(s.scenario.Name,
+		testing.WithVUID(id),
 		testing.WithLogger(s.logger),
 		testing.WithLogrusLogger(s.logrusLogger),
 	)

--- a/internal/workers/pool_manager.go
+++ b/internal/workers/pool_manager.go
@@ -32,7 +32,7 @@ func New(maxIterations uint64, activeScenario *ActiveScenario) *PoolManager {
 func (m *PoolManager) makeIterationStatePool(numWorkers int) []*iterationState {
 	statePool := make([]*iterationState, numWorkers)
 	for i := range numWorkers {
-		statePool[i] = m.activeScenario.newIterationState()
+		statePool[i] = m.activeScenario.newIterationState(i)
 	}
 
 	return statePool

--- a/pkg/f1/testing/t.go
+++ b/pkg/f1/testing/t.go
@@ -28,6 +28,7 @@ type T struct {
 	require        *require.Assertions
 	Iteration      string // iteration number or "setup"
 	Scenario       string
+	VUID           int
 	teardownStack  []func()
 	failed         atomic.Bool
 	teardownFailed atomic.Bool
@@ -54,6 +55,12 @@ func WithLogger(logger *slog.Logger) TOption {
 func WithIteration(iteration string) TOption {
 	return func(t *T) {
 		t.Iteration = iteration
+	}
+}
+
+func WithVUID(id int) TOption {
+	return func(t *T) {
+		t.VUID = id
 	}
 }
 


### PR DESCRIPTION
A quick implementation to assign a distinct integer VUID to each pool worker re: #309.