### PR TITLE
chore: make 'waitForCompletionTimeout' configurable with a flag

### DIFF
--- a/internal/options/run_options.go
+++ b/internal/options/run_options.go
@@ -5,14 +5,15 @@ import (
 )
 
 type RunOptions struct {
-	Scenario        string
-	MaxDuration     time.Duration
-	Concurrency     int
-	MaxIterations   uint64
-	MaxFailures     uint64
-	MaxFailuresRate int
-	Verbose         bool
-	IgnoreDropped   bool
+	Scenario                 string
+	MaxDuration              time.Duration
+	Concurrency              int
+	MaxIterations            uint64
+	MaxFailures              uint64
+	MaxFailuresRate          int
+	Verbose                  bool
+	IgnoreDropped            bool
+	WaitForCompletionTimeout time.Duration
 }
 
 func (o *RunOptions) LogToFile() bool {

--- a/internal/run/run_cmd.go
+++ b/internal/run/run_cmd.go
@@ -16,8 +16,6 @@ import (
 	"github.com/form3tech-oss/f1/v2/pkg/f1/scenarios"
 )
 
-const waitForCompletionTimeout = 10 * time.Second
-
 func Cmd(
 	s *scenarios.Scenarios,
 	builders []api.Builder,
@@ -55,6 +53,8 @@ func Cmd(
 				"--max-failures 10 (load test will fail if more than 10 errors occurred, default is 0)")
 			triggerCmd.Flags().Int(triggerflags.FlagMaxFailuresRate, 0,
 				"--max-failures-rate 5 (load test will fail if more than 5\\% requests failed, default is 0)")
+			triggerCmd.Flags().Duration(triggerflags.FlagWaitForCompletionTimeout, 10*time.Second,
+				"--wait-for-completion-timeout 10s (wait for completion for 10 seconds)")
 		}
 
 		triggerCmd.Flags().AddFlagSet(t.Flags)
@@ -87,6 +87,7 @@ func runCmdExecute(
 		var maxFailures uint64
 		var maxFailuresRate int
 		var ignoreDropped bool
+		var waitForCompletionTimeout time.Duration
 		if t.IgnoreCommonFlags {
 			scenarioName = trig.Options.Scenario
 			duration = trig.Options.MaxDuration
@@ -95,6 +96,7 @@ func runCmdExecute(
 			maxFailures = trig.Options.MaxFailures
 			maxFailuresRate = trig.Options.MaxFailuresRate
 			ignoreDropped = trig.Options.IgnoreDropped
+			waitForCompletionTimeout = trig.Options.WaitForCompletionTimeout
 		} else {
 			scenarioName = args[0]
 			duration, err = cmd.Flags().GetDuration(triggerflags.FlagMaxDuration)
@@ -125,6 +127,10 @@ func runCmdExecute(
 			if err != nil {
 				return fmt.Errorf("getting flag: %w", err)
 			}
+			waitForCompletionTimeout, err = cmd.Flags().GetDuration(triggerflags.FlagWaitForCompletionTimeout)
+			if err != nil {
+				return fmt.Errorf("getting flag: %w", err)
+			}
 		}
 
 		verbose, err := cmd.Flags().GetBool(triggerflags.FlagVerbose)
@@ -151,15 +157,16 @@ func runCmdExecute(
 		}
 
 		run, err := NewRun(options.RunOptions{
-			Scenario:        scenarioName,
-			MaxDuration:     duration,
-			Concurrency:     concurrency,
-			Verbose:         verbose,
-			MaxIterations:   maxIterations,
-			MaxFailures:     maxFailures,
-			MaxFailuresRate: maxFailuresRate,
-			IgnoreDropped:   ignoreDropped,
-		}, s, trig, waitForCompletionTimeout, settings, metricsInstance, output)
+			Scenario:                 scenarioName,
+			MaxDuration:              duration,
+			Concurrency:              concurrency,
+			Verbose:                  verbose,
+			MaxIterations:            maxIterations,
+			MaxFailures:              maxFailures,
+			MaxFailuresRate:          maxFailuresRate,
+			IgnoreDropped:            ignoreDropped,
+			WaitForCompletionTimeout: waitForCompletionTimeout,
+		}, s, trig, settings, metricsInstance, output)
 		if err != nil {
 			return fmt.Errorf("new run: %w", err)
 		}

--- a/internal/run/run_stage_test.go
+++ b/internal/run/run_stage_test.go
@@ -198,14 +198,15 @@ func (s *RunTestStage) setupRun() {
 	outputer := ui.NewOutput(logger, printer, s.interactive, false)
 
 	r, err := run.NewRun(options.RunOptions{
-		Scenario:        s.scenario,
-		MaxDuration:     s.duration,
-		Concurrency:     s.concurrency,
-		MaxIterations:   s.maxIterations,
-		MaxFailures:     s.maxFailures,
-		MaxFailuresRate: s.maxFailuresRate,
-		Verbose:         s.verbose,
-	}, s.f1.GetScenarios(), s.build_trigger(), s.waitForCompletionTimeout, s.settings, s.metrics, outputer)
+		Scenario:                 s.scenario,
+		MaxDuration:              s.duration,
+		Concurrency:              s.concurrency,
+		MaxIterations:            s.maxIterations,
+		MaxFailures:              s.maxFailures,
+		MaxFailuresRate:          s.maxFailuresRate,
+		Verbose:                  s.verbose,
+		WaitForCompletionTimeout: s.waitForCompletionTimeout,
+	}, s.f1.GetScenarios(), s.build_trigger(), s.settings, s.metrics, outputer)
 
 	s.require.NoError(err)
 	s.runInstance = r

--- a/internal/run/test_runner.go
+++ b/internal/run/test_runner.go
@@ -30,24 +30,22 @@ const (
 )
 
 type Run struct {
-	pusher                   *push.Pusher
-	progressRunner           *raterun.Runner
-	metrics                  *metrics.Metrics
-	views                    *views.Views
-	activeScenario           *workers.ActiveScenario
-	trigger                  *api.Trigger
-	output                   *ui.Output
-	scenarioLogger           *ScenarioLogger
-	result                   *Result
-	options                  options.RunOptions
-	waitForCompletionTimeout time.Duration
+	pusher         *push.Pusher
+	progressRunner *raterun.Runner
+	metrics        *metrics.Metrics
+	views          *views.Views
+	activeScenario *workers.ActiveScenario
+	trigger        *api.Trigger
+	output         *ui.Output
+	scenarioLogger *ScenarioLogger
+	result         *Result
+	options        options.RunOptions
 }
 
 func NewRun(
 	options options.RunOptions,
 	scenarios *scenarios.Scenarios,
 	trigger *api.Trigger,
-	waitForCompletionTimeout time.Duration,
 	settings envsettings.Settings,
 	metricsInstance *metrics.Metrics,
 	parentOutput *ui.Output,
@@ -93,17 +91,16 @@ func NewRun(
 	pusher := newMetricsPusher(settings, scenario.Name, metricsInstance)
 
 	return &Run{
-		options:                  options,
-		trigger:                  trigger,
-		metrics:                  metricsInstance,
-		views:                    viewsInstance,
-		result:                   result,
-		pusher:                   pusher,
-		output:                   outputer,
-		progressRunner:           progressRunner,
-		activeScenario:           activeScenario,
-		scenarioLogger:           scenarioLogger,
-		waitForCompletionTimeout: waitForCompletionTimeout,
+		options:        options,
+		trigger:        trigger,
+		metrics:        metricsInstance,
+		views:          viewsInstance,
+		result:         result,
+		pusher:         pusher,
+		output:         outputer,
+		progressRunner: progressRunner,
+		activeScenario: activeScenario,
+		scenarioLogger: scenarioLogger,
 	}, nil
 }
 
@@ -259,9 +256,10 @@ func (r *Run) run(ctx context.Context) {
 		r.progressRunner.Restart()
 		select {
 		case <-poolManager.WaitForCompletion():
-		case <-time.After(r.waitForCompletionTimeout):
+		case <-time.After(r.options.WaitForCompletionTimeout):
 			r.output.Display(ui.WarningMessage{
-				Message: fmt.Sprintf("Active tests not completed after %s. Stopping...", r.waitForCompletionTimeout.String()),
+				Message: fmt.Sprintf("Active tests not completed after %s. Stopping...",
+					r.options.WaitForCompletionTimeout.String()),
 			})
 		}
 
@@ -273,9 +271,10 @@ func (r *Run) run(ctx context.Context) {
 		}
 		select {
 		case <-poolManager.WaitForCompletion():
-		case <-time.After(r.waitForCompletionTimeout):
+		case <-time.After(r.options.WaitForCompletionTimeout):
 			r.output.Display(ui.WarningMessage{
-				Message: fmt.Sprintf("Active tests not completed after %s. Stopping...", r.waitForCompletionTimeout.String()),
+				Message: fmt.Sprintf("Active tests not completed after %s. Stopping...",
+					r.options.WaitForCompletionTimeout.String()),
 			})
 		}
 	case <-poolManager.WaitForCompletion():

--- a/internal/trigger/api/api.go
+++ b/internal/trigger/api/api.go
@@ -42,15 +42,16 @@ type Trigger struct {
 }
 
 type Options struct {
-	Scenario        string
-	MaxDuration     time.Duration
-	Concurrency     int
-	MaxIterations   uint64
-	MaxFailures     uint64
-	MaxFailuresRate int
-	Verbose         bool
-	VerboseFail     bool
-	IgnoreDropped   bool
+	Scenario                 string
+	MaxDuration              time.Duration
+	Concurrency              int
+	MaxIterations            uint64
+	MaxFailures              uint64
+	MaxFailuresRate          int
+	Verbose                  bool
+	VerboseFail              bool
+	IgnoreDropped            bool
+	WaitForCompletionTimeout time.Duration
 }
 
 type Rates struct {

--- a/internal/trigger/file/file_parser.go
+++ b/internal/trigger/file/file_parser.go
@@ -26,12 +26,13 @@ type Schedule struct {
 }
 
 type Limits struct {
-	MaxDuration     *time.Duration `yaml:"max-duration"`
-	Concurrency     *int           `yaml:"concurrency"`
-	MaxIterations   *uint64        `yaml:"max-iterations"`
-	MaxFailures     *uint64        `yaml:"max-failures"`
-	MaxFailuresRate *int           `yaml:"max-failures-rate"`
-	IgnoreDropped   *bool          `yaml:"ignore-dropped"`
+	MaxDuration              *time.Duration `yaml:"max-duration"`
+	Concurrency              *int           `yaml:"concurrency"`
+	MaxIterations            *uint64        `yaml:"max-iterations"`
+	MaxFailures              *uint64        `yaml:"max-failures"`
+	MaxFailuresRate          *int           `yaml:"max-failures-rate"`
+	IgnoreDropped            *bool          `yaml:"ignore-dropped"`
+	WaitForCompletionTimeout *time.Duration `yaml:"wait-for-completion-timeout"`
 }
 
 type Stage struct {
@@ -84,15 +85,16 @@ func ParseConfigFile(fileContent []byte, now time.Time) (*RunnableStages, error)
 	}
 
 	return &RunnableStages{
-		Scenario:            *validatedConfigFile.Scenario,
-		Stages:              stages,
-		stagesTotalDuration: stagesTotalDuration,
-		MaxDuration:         *validatedConfigFile.Limits.MaxDuration,
-		Concurrency:         *validatedConfigFile.Limits.Concurrency,
-		MaxIterations:       *validatedConfigFile.Limits.MaxIterations,
-		maxFailures:         *validatedConfigFile.Limits.MaxFailures,
-		maxFailuresRate:     *validatedConfigFile.Limits.MaxFailuresRate,
-		IgnoreDropped:       *validatedConfigFile.Limits.IgnoreDropped,
+		Scenario:                 *validatedConfigFile.Scenario,
+		Stages:                   stages,
+		stagesTotalDuration:      stagesTotalDuration,
+		MaxDuration:              *validatedConfigFile.Limits.MaxDuration,
+		Concurrency:              *validatedConfigFile.Limits.Concurrency,
+		MaxIterations:            *validatedConfigFile.Limits.MaxIterations,
+		maxFailures:              *validatedConfigFile.Limits.MaxFailures,
+		maxFailuresRate:          *validatedConfigFile.Limits.MaxFailuresRate,
+		IgnoreDropped:            *validatedConfigFile.Limits.IgnoreDropped,
+		WaitForCompletionTimeout: *validatedConfigFile.Limits.WaitForCompletionTimeout,
 	}, nil
 }
 
@@ -224,6 +226,10 @@ func (c *ConfigFile) validateCommonFields() (*ConfigFile, error) {
 	if c.Limits.MaxFailuresRate == nil {
 		maxFailuresRate := 0
 		c.Limits.MaxFailuresRate = &maxFailuresRate
+	}
+	if c.Limits.WaitForCompletionTimeout == nil {
+		waitForCompletionTimeout := 10 * time.Second
+		c.Limits.WaitForCompletionTimeout = &waitForCompletionTimeout
 	}
 	if c.Default.Concurrency == nil {
 		c.Default.Concurrency = c.Limits.Concurrency

--- a/internal/trigger/file/file_parser_test.go
+++ b/internal/trigger/file/file_parser_test.go
@@ -382,6 +382,35 @@ stages:
 			expectedRates:             []int{6, 6, 6, 6, 6, 6},
 			expectedParameters:        map[string]string{"FOO": "bar"},
 		},
+		{
+			testName: "Include wait for completion timeout",
+			fileContent: `scenario: template
+limits:
+  max-duration: 1m
+  concurrency: 50
+  max-iterations: 100
+  ignore-dropped: true
+  wait-for-completion-timeout: 5s
+stages:
+- duration: 5s
+  mode: constant
+  rate: 6/s
+  jitter: 0
+  distribution: none
+  parameters:
+    FOO: bar
+`,
+			expectedScenario:                 "template",
+			expectedMaxDuration:              1 * time.Minute,
+			expectedConcurrency:              50,
+			expectedMaxIterations:            100,
+			expectedIgnoreDropped:            true,
+			expectedWaitForCompletionTimeout: 5 * time.Second,
+			expectedTotalDuration:            5 * time.Second,
+			expectedIterationDuration:        1 * time.Second,
+			expectedRates:                    []int{6, 6, 6, 6, 6, 6},
+			expectedParameters:               map[string]string{"FOO": "bar"},
+		},
 	} {
 		t.Run(test.testName, func(t *testing.T) {
 			t.Parallel()
@@ -664,18 +693,19 @@ invalid file content
 }
 
 type testData struct {
-	testName                  string
-	fileContent               string
-	expectedScenario          string
-	expectedTotalDuration     time.Duration
-	expectedIterationDuration time.Duration
-	expectedMaxDuration       time.Duration
-	expectedIgnoreDropped     bool
-	expectedMaxIterations     uint64
-	expectedMaxFailures       int
-	expectedMaxFailuresRate   int
-	expectedConcurrency       int
-	expectedUsersConcurrency  int
-	expectedRates             []int
-	expectedParameters        map[string]string
+	testName                         string
+	fileContent                      string
+	expectedScenario                 string
+	expectedTotalDuration            time.Duration
+	expectedIterationDuration        time.Duration
+	expectedMaxDuration              time.Duration
+	expectedIgnoreDropped            bool
+	expectedWaitForCompletionTimeout time.Duration
+	expectedMaxIterations            uint64
+	expectedMaxFailures              int
+	expectedMaxFailuresRate          int
+	expectedConcurrency              int
+	expectedUsersConcurrency         int
+	expectedRates                    []int
+	expectedParameters               map[string]string
 }

--- a/internal/trigger/file/file_rate.go
+++ b/internal/trigger/file/file_rate.go
@@ -14,15 +14,16 @@ import (
 )
 
 type RunnableStages struct {
-	Scenario            string
-	Stages              []runnableStage
-	stagesTotalDuration time.Duration
-	MaxDuration         time.Duration
-	Concurrency         int
-	MaxIterations       uint64
-	maxFailures         uint64
-	maxFailuresRate     int
-	IgnoreDropped       bool
+	Scenario                 string
+	Stages                   []runnableStage
+	stagesTotalDuration      time.Duration
+	MaxDuration              time.Duration
+	Concurrency              int
+	MaxIterations            uint64
+	maxFailures              uint64
+	maxFailuresRate          int
+	IgnoreDropped            bool
+	WaitForCompletionTimeout time.Duration
 }
 
 type runnableStage struct {
@@ -57,13 +58,14 @@ func Rate(output *ui.Output) api.Builder {
 				Description: fmt.Sprintf("%d different stages", len(runnableStages.Stages)),
 				Duration:    runnableStages.stagesTotalDuration,
 				Options: api.Options{
-					Scenario:        runnableStages.Scenario,
-					MaxDuration:     runnableStages.MaxDuration,
-					Concurrency:     runnableStages.Concurrency,
-					MaxIterations:   runnableStages.MaxIterations,
-					MaxFailures:     runnableStages.maxFailures,
-					MaxFailuresRate: runnableStages.maxFailuresRate,
-					IgnoreDropped:   runnableStages.IgnoreDropped,
+					Scenario:                 runnableStages.Scenario,
+					MaxDuration:              runnableStages.MaxDuration,
+					Concurrency:              runnableStages.Concurrency,
+					MaxIterations:            runnableStages.MaxIterations,
+					MaxFailures:              runnableStages.maxFailures,
+					MaxFailuresRate:          runnableStages.maxFailuresRate,
+					IgnoreDropped:            runnableStages.IgnoreDropped,
+					WaitForCompletionTimeout: runnableStages.WaitForCompletionTimeout,
 				},
 			}, nil
 		},

--- a/internal/triggerflags/flags.go
+++ b/internal/triggerflags/flags.go
@@ -9,14 +9,15 @@ import (
 )
 
 const (
-	FlagVerbose         = "verbose"
-	FlagVerboseFail     = "verbose-fail"
-	FlagIgnoreDropped   = "ignore-dropped"
-	FlagMaxDuration     = "max-duration"
-	FlagMaxIterations   = "max-iterations"
-	FlagConcurrency     = "concurrency"
-	FlagMaxFailures     = "max-failures"
-	FlagMaxFailuresRate = "max-failures-rate"
+	FlagVerbose                  = "verbose"
+	FlagVerboseFail              = "verbose-fail"
+	FlagIgnoreDropped            = "ignore-dropped"
+	FlagMaxDuration              = "max-duration"
+	FlagMaxIterations            = "max-iterations"
+	FlagConcurrency              = "concurrency"
+	FlagMaxFailures              = "max-failures"
+	FlagMaxFailuresRate          = "max-failures-rate"
+	FlagWaitForCompletionTimeout = "wait-for-completion-timeout"
 )
 
 const FlagDistribution = "distribution"


### PR DESCRIPTION
Currently, the `waitForCompletionTimeout` variable is hardcoded to 10 seconds, which prohibits the use of scenarios that take longer than 10 seconds.
While it's not necessarily fitting the core problem statement of a load testing framework, there are cases where this tool can be used for scenarios that take more than the default 10 seconds.
This PR addresses this issue by making the timeout configurable with a command argument, still using the 10 seconds as a default.
